### PR TITLE
Fix Railway healthcheck failure: port variable not interpreted

### DIFF
--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -3,7 +3,7 @@ builder = "dockerfile"
 dockerfilePath = "./Dockerfile"
 
 [deploy]
-startCommand = "uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000}"
+startCommand = "bash -c 'uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000}'"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"


### PR DESCRIPTION
## Summary
- Railway executes the start command directly without a shell, so `${PORT:-8000}` was passed as a literal string to uvicorn
- Wrapped the command in `bash -c '...'` so the shell variable is properly interpreted

## Test plan
- [ ] Deploy to Railway and verify healthcheck passes
- [ ] Confirm app is reachable on the assigned port

🤖 Generated with [Claude Code](https://claude.com/claude-code)