### PR TITLE
Fix wiki sync workflow: rebase before push

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -18,4 +18,8 @@ jobs:
         run: |
           cd wiki
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/mateonoel2/capstone-project.wiki.git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin master
+          git rebase origin/master
           git push origin HEAD:master


### PR DESCRIPTION
## Summary
- Add `fetch + rebase` step to wiki sync workflow so it handles cases where the wiki remote has commits not in the submodule
- Sync wiki submodule with latest remote state

## Test plan
- [x] Wiki pages pushed successfully to remote
- [ ] Verify workflow runs on next merge with wiki changes

Generated with [Claude Code](https://claude.com/claude-code)