### PR TITLE
Replace wiki submodule with regular directory

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -4,22 +4,21 @@ on:
   push:
     branches: [main]
     paths:
-      - "wiki"
+      - "wiki/**"
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Push wiki changes
         run: |
-          cd wiki
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/mateonoel2/capstone-project.wiki.git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin master
-          git rebase origin/master
-          git push origin HEAD:master
+          git clone https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/mateonoel2/capstone-project.wiki.git /tmp/wiki-remote
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          cp wiki/*.md /tmp/wiki-remote/
+          cd /tmp/wiki-remote
+          git add -A
+          git diff --cached --quiet || git commit -m "Sync wiki from main repo"
+          git push origin master

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -18,4 +18,8 @@ jobs:
         run: |
           cd wiki
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/mateonoel2/capstone-project.wiki.git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin master
+          git rebase origin/master
           git push origin HEAD:master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "wiki"]
-	path = wiki
-	url = https://github.com/mateonoel2/capstone-project.wiki.git


### PR DESCRIPTION
## Summary
- Remove wiki git submodule (delete `.gitmodules`)
- Track wiki files as regular directory in the repo
- Update sync workflow to clone wiki repo, copy files, and push

This fixes the fundamental issue where the submodule approach required manually pushing to the wiki remote first, making automatic sync impossible.

## Test plan
- [ ] Verify wiki files are tracked as regular files
- [ ] Verify sync workflow triggers on next merge with wiki changes

Generated with [Claude Code](https://claude.com/claude-code)