### PR TITLE
Add authentication and multi-tenancy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,17 +45,20 @@ Three layers under `src/`:
   - `constants.py` — `UNKNOWN_OWNER`, `UNKNOWN_ACCOUNT`, `CLABE_LENGTH`, `BANK_DICT_KUSHKI`
   - `validators.py` — CLABE/bank regex patterns and validation
   - `extractor_interface.py` — `BaseExtractor` ABC
-  - `entities.py` — `SubmissionData`, `MetricsData`, `ApiCallResult`, `ApiCallMetricsData`, `ExtractionError`, `ExtractorConfigData`
+  - `entities.py` — `SubmissionData`, `MetricsData`, `ApiCallResult`, `ApiCallMetricsData`, `ExtractionError`, `ExtractorConfigData`, `UserData`
   - `services/` — `ExtractionService`, `SubmissionService`, `MetricsService`, `ApiMetricsService`, `ExtractorConfigService`
 
 - **`src/infrastructure/`** — External integrations
+  - `api/auth/routes.py` — Authentication routes (`/auth/login`, `/auth/me`)
+  - `api/admin/routes.py` — Admin routes for user management (`/admin/users` CRUD)
   - `api/extraction/routes.py` — HTTP routes under `/extraction`
   - `api/extraction/dtos.py` — Request/response Pydantic models
   - `api/extractors/routes.py` — HTTP routes under `/extractors` (CRUD, versioning, AI generation, test extraction)
+  - `auth.py` — JWT token creation/validation, `get_current_user`/`get_admin_user` dependencies, GitHub token validation
   - `ai_assist.py` — Claude-powered schema generation, prompt generation, and prompt refinement
   - `database.py` — SQLAlchemy engine + session (PostgreSQL via `DATABASE_URL`)
-  - `models.py` — `ExtractorConfig`, `ExtractorConfigVersion`, `ExtractionLog`, `ApiCallLog`, `TestExtractionLog` ORM models
-  - `repository.py` — `ExtractionRepository`, `ExtractorConfigRepository`, `ApiCallRepository`, `TestExtractionLogRepository`
+  - `models.py` — `User`, `ExtractorConfig`, `ExtractorConfigVersion`, `ExtractionLog`, `ApiCallLog`, `TestExtractionLog` ORM models
+  - `repository.py` — `UserRepository`, `ExtractionRepository`, `ExtractorConfigRepository`, `ApiCallRepository`, `TestExtractionLogRepository`
   - `storage.py` — `StorageBackend` ABC with `LocalStorage` and `S3Storage` (presigned upload URLs, download, CORS config)
   - `extractors/` — `StatementExtractor`: unified vision-based extractor (PDF + images)
   - `preprocessing/` — `OCRProcessor`, `DataCleaner`, `FileValidator`, `FileDownloader`
@@ -68,20 +71,28 @@ Three layers under `src/`:
 
 Next.js 15 App Router with TypeScript, Tailwind CSS, Radix UI (shadcn/ui), React Query for server state, and Zustand for UI state.
 
+- `/login` — GitHub OAuth login page
 - `/` — Main extraction workflow: upload file (PDF/JPG/PNG) → preview → editable extracted fields → submit
 - `/extractors` — Extractor config management (list, create, edit, delete)
 - `/extractors/new` — Multi-step wizard to create extractor configs (identity, schema, prompt, test)
 - `/extractors/[id]/edit` — Edit existing extractor config
 - `/dashboard` — Accuracy metrics and extraction history
+- `/admin/users` — User management (admin only): create, edit roles, activate/deactivate, delete
+- `auth.ts` — NextAuth.js configuration (GitHub provider, JWT callbacks)
+- `middleware.ts` — Route protection (redirects unauthenticated users to `/login`)
+- `components/auth-provider.tsx` — `SessionProvider` + `BackendAuthSync` (exchanges GitHub token for backend JWT)
+- `components/app-shell.tsx` — Conditional layout (hides sidebar on login page)
 - `components/assistant/` — AI-powered sidebar for schema/prompt generation
 - `components/extractor-wizard/` — Multi-step wizard components
-- `lib/hooks.ts` — React Query hooks for server state (configs, versions, AI generation, extraction)
+- `lib/hooks.ts` — React Query hooks for server state (configs, versions, AI generation, extraction, users)
 - `lib/query-provider.tsx` — React Query provider configuration
-- `lib/store.ts` — Zustand store (sessionStorage persistence, UI state)
-- `lib/api.ts` — Typed fetch wrappers for backend endpoints
+- `lib/store.ts` — Zustand store (sessionStorage persistence, UI state, backend auth token/user)
+- `lib/api.ts` — Typed fetch wrappers for backend endpoints (includes JWT Authorization header)
 
 ## Key Domain Concepts
 
+- **Authentication**: GitHub OAuth via NextAuth.js (frontend) + JWT tokens for backend API. Frontend exchanges GitHub access token for a backend JWT via `POST /auth/login`
+- **Multi-tenancy**: `users` table with roles (`user`/`admin`). All data tables have `user_id` FK. Extractor configs scoped per user (unique name per user). Admin pre-registers users by GitHub username
 - **Extractor config**: User-defined extraction configuration with name, model, prompt, and JSON output schema. Supports draft/active status and versioning for A/B testing
 - **Upload flow**: Frontend requests presigned URL → direct S3 PUT (with backend fallback) → extract by S3 key
 - **Extraction flow**: S3 key → download from storage → vision-based Claude extractor (using config's prompt + schema) → structured output → user correction → persistence with correction flags
@@ -94,10 +105,14 @@ Next.js 15 App Router with TypeScript, Tailwind CSS, Radix UI (shadcn/ui), React
 
 - `ANTHROPIC_API_KEY` — Required for Claude API calls (backend)
 - `DATABASE_URL` — PostgreSQL connection string (backend)
+- `JWT_SECRET` — Secret key for signing JWT tokens (backend, defaults to dev value)
 - `AWS_ENDPOINT_URL` — S3/LocalStack endpoint (backend)
 - `AWS_PUBLIC_ENDPOINT_URL` — Browser-reachable S3 endpoint for presigned URLs (defaults to `AWS_ENDPOINT_URL`)
 - `AWS_S3_BUCKET_NAME` — S3 bucket for PDF uploads (backend)
 - `NEXT_PUBLIC_API_URL` — Backend URL, defaults to `http://localhost:8000` (frontend)
+- `AUTH_GITHUB_ID` — GitHub OAuth App client ID (frontend)
+- `AUTH_GITHUB_SECRET` — GitHub OAuth App client secret (frontend)
+- `AUTH_SECRET` / `NEXTAUTH_SECRET` — NextAuth.js secret for session encryption (frontend)
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Sistema de producción (*FastAPI* + *Next.js*) que extrae información estructur
 ## Características
 
 - Aplicacion web con *FastAPI* (*backend*) y *Next.js* 15 (*frontend*)
+- Autenticacion con *GitHub OAuth* (*NextAuth.js*) y tokens *JWT* en el *backend*
+- *Multi-tenancy*: tabla de usuarios con roles (*user*/*admin*), datos aislados por usuario
+- Panel de administracion para gestion de usuarios (crear, editar rol, activar/desactivar, eliminar)
 - Extractores configurables con *schemas*, *prompts* y modelos personalizados
 - *Wizard* multi-paso para crear extractores (identidad, *schema*, *prompt*, prueba)
 - Asistente de IA para generacion de *schemas* y *prompts* (alimentado por Claude)
@@ -44,11 +47,14 @@ capstone-project/
 │   │   │   ├── entities.py           # Entidades de dominio y API calls
 │   │   │   └── services/             # ExtractionService, SubmissionService, MetricsService, ExtractorConfigService
 │   │   ├── infrastructure/            # Integraciones externas
+│   │   │   │   ├── api/auth/             # Rutas de autenticación (/auth)
+│   │   │   ├── api/admin/            # Rutas de administración (/admin/users)
 │   │   │   ├── api/extraction/       # Rutas HTTP y DTOs (/extraction)
 │   │   │   ├── api/extractors/       # Rutas HTTP (/extractors CRUD, AI, test)
+│   │   │   ├── auth.py                # JWT y validación de tokens GitHub
 │   │   │   ├── ai_assist.py          # Generacion de schemas/prompts con Claude
 │   │   │   ├── database.py           # SQLAlchemy + PostgreSQL
-│   │   │   ├── models.py             # ORM (ExtractionLog, ApiCallLog, TestExtractionLog)
+│   │   │   ├── models.py             # ORM (User, ExtractionLog, ApiCallLog, etc.)
 │   │   │   ├── repository.py         # Acceso a datos
 │   │   │   ├── storage.py            # StorageBackend (S3 / local)
 │   │   │   ├── extractors/           # StatementExtractor (vision unificado)
@@ -62,8 +68,11 @@ capstone-project/
 │   └── data/                          # Datos de prueba
 │
 ├── frontend/                          # Next.js 15 (App Router)
-│   ├── app/                           # Páginas (/, /extractors, /dashboard)
+│   ├── app/                           # Páginas (/, /login, /extractors, /dashboard, /admin)
+│   ├── auth.ts                        # Configuración NextAuth.js (GitHub OAuth)
+│   ├── middleware.ts                  # Protección de rutas (redirige a /login)
 │   ├── components/                    # Componentes React + shadcn/ui
+│   │   ├── auth-provider.tsx         # Proveedor de autenticación (NextAuth + JWT backend)
 │   │   ├── assistant/                # Sidebar de asistente IA
 │   │   └── extractor-wizard/        # Wizard multi-paso para extractores
 │   └── lib/                           # API client, React Query hooks, Zustand store
@@ -145,10 +154,14 @@ ruff format .   # formato
 |---|---|
 | `ANTHROPIC_API_KEY` | API key de Anthropic (backend) |
 | `DATABASE_URL` | URL de PostgreSQL (backend) |
+| `JWT_SECRET` | Clave secreta para firmar tokens JWT (backend) |
 | `AWS_ENDPOINT_URL` | Endpoint S3 / LocalStack (backend) |
 | `AWS_PUBLIC_ENDPOINT_URL` | Endpoint S3 accesible desde el navegador para *presigned URLs* (default: `AWS_ENDPOINT_URL`) |
 | `AWS_S3_BUCKET_NAME` | Nombre del bucket S3 (backend) |
 | `NEXT_PUBLIC_API_URL` | URL del backend, default `http://localhost:8000` (frontend) |
+| `AUTH_GITHUB_ID` | Client ID de la GitHub OAuth App (frontend) |
+| `AUTH_GITHUB_SECRET` | Client secret de la GitHub OAuth App (frontend) |
+| `AUTH_SECRET` | Secreto de NextAuth.js para cifrado de sesiones (frontend) |
 
 ## Licencia
 

--- a/backend/alembic/versions/i9d0e1f2a3b4_add_users_and_multi_tenancy.py
+++ b/backend/alembic/versions/i9d0e1f2a3b4_add_users_and_multi_tenancy.py
@@ -1,0 +1,146 @@
+"""Add users table and multi-tenancy support
+
+Revision ID: i9d0e1f2a3b4
+Revises: h8c9d0e1f2a3
+Create Date: 2026-03-18
+"""
+
+import sqlalchemy as sa
+
+from alembic import context, op
+
+revision = "i9d0e1f2a3b4"
+down_revision = "h8c9d0e1f2a3"
+branch_labels = None
+depends_on = None
+
+
+def _is_sqlite() -> bool:
+    return context.get_context().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    # 1. Create users table
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("github_id", sa.Integer(), unique=True, nullable=True, index=True),
+        sa.Column("github_username", sa.String(100), unique=True, nullable=False),
+        sa.Column("email", sa.String(255), nullable=True),
+        sa.Column("avatar_url", sa.String(500), nullable=True),
+        sa.Column("role", sa.String(20), nullable=False, server_default="user"),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("last_login_at", sa.DateTime(), nullable=True),
+    )
+
+    # 2. Seed admin user
+    op.execute(sa.text("INSERT INTO users (github_username, role) VALUES ('mateonoel2', 'admin')"))
+
+    # 3. Add user_id column + FK to existing tables
+    tables_needing_user_id = [
+        "extraction_logs",
+        "api_call_logs",
+        "test_extraction_logs",
+    ]
+
+    if _is_sqlite():
+        # SQLite: use batch mode for ALTER support
+        for table in tables_needing_user_id:
+            with op.batch_alter_table(table) as batch_op:
+                batch_op.add_column(sa.Column("user_id", sa.Integer(), nullable=True))
+                batch_op.create_foreign_key(f"fk_{table}_user_id", "users", ["user_id"], ["id"])
+
+        # extractor_configs: also replace unique(name)
+        naming = {"uq": "uq_%(table_name)s_%(column_0_name)s"}
+        with op.batch_alter_table("extractor_configs", naming_convention=naming) as batch_op:
+            batch_op.add_column(sa.Column("user_id", sa.Integer(), nullable=True))
+            batch_op.create_foreign_key(
+                "fk_extractor_configs_user_id",
+                "users",
+                ["user_id"],
+                ["id"],
+            )
+            batch_op.drop_constraint("uq_extractor_configs_name", type_="unique")
+            batch_op.create_unique_constraint("uq_extractor_configs_name_user", ["name", "user_id"])
+    else:
+        # PostgreSQL: direct ALTER
+        for table in tables_needing_user_id:
+            op.add_column(table, sa.Column("user_id", sa.Integer(), nullable=True))
+            op.create_foreign_key(f"fk_{table}_user_id", table, "users", ["user_id"], ["id"])
+
+        op.add_column(
+            "extractor_configs",
+            sa.Column("user_id", sa.Integer(), nullable=True),
+        )
+        op.create_foreign_key(
+            "fk_extractor_configs_user_id",
+            "extractor_configs",
+            "users",
+            ["user_id"],
+            ["id"],
+        )
+        # Constraint kept old name from when table was parser_configs
+        op.drop_constraint(
+            "parser_configs_name_key",
+            "extractor_configs",
+            type_="unique",
+        )
+        op.create_unique_constraint(
+            "uq_extractor_configs_name_user",
+            "extractor_configs",
+            ["name", "user_id"],
+        )
+
+    # 4. Backfill: assign all existing rows to admin user
+    admin_sub = "(SELECT id FROM users WHERE role = 'admin' LIMIT 1)"
+    all_tables = ["extractor_configs"] + tables_needing_user_id
+    for table in all_tables:
+        op.execute(sa.text(f"UPDATE {table} SET user_id = {admin_sub}"))
+
+
+def downgrade() -> None:
+    if _is_sqlite():
+        naming = {"uq": "uq_%(table_name)s_%(column_0_name)s"}
+        with op.batch_alter_table("extractor_configs", naming_convention=naming) as batch_op:
+            batch_op.drop_constraint("uq_extractor_configs_name_user", type_="unique")
+            batch_op.create_unique_constraint("uq_extractor_configs_name", ["name"])
+            batch_op.drop_constraint("fk_extractor_configs_user_id", type_="foreignkey")
+            batch_op.drop_column("user_id")
+
+        for table in [
+            "test_extraction_logs",
+            "api_call_logs",
+            "extraction_logs",
+        ]:
+            with op.batch_alter_table(table) as batch_op:
+                batch_op.drop_constraint(f"fk_{table}_user_id", type_="foreignkey")
+                batch_op.drop_column("user_id")
+    else:
+        op.drop_constraint(
+            "uq_extractor_configs_name_user",
+            "extractor_configs",
+            type_="unique",
+        )
+        op.create_unique_constraint("parser_configs_name_key", "extractor_configs", ["name"])
+        op.drop_constraint(
+            "fk_extractor_configs_user_id",
+            "extractor_configs",
+            type_="foreignkey",
+        )
+        op.drop_column("extractor_configs", "user_id")
+
+        for table in [
+            "test_extraction_logs",
+            "api_call_logs",
+            "extraction_logs",
+        ]:
+            op.drop_constraint(f"fk_{table}_user_id", table, type_="foreignkey")
+            op.drop_column(table, "user_id")
+
+    op.drop_table("users")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
     "boto3>=1.34.0",
     "alembic>=1.13.0",
+    "PyJWT>=2.8.0",
     "langchain-anthropic>=0.3.0",
 ]
 

--- a/backend/src/domain/entities.py
+++ b/backend/src/domain/entities.py
@@ -43,6 +43,7 @@ class ExtractorConfigData:
     output_schema: dict
     is_default: bool
     status: str = "active"
+    user_id: int | None = None
     created_at: object | None = None
     updated_at: object | None = None
 
@@ -57,6 +58,17 @@ class ExtractorConfigVersionData:
     output_schema: dict
     is_active: bool
     created_at: object | None = None
+
+
+@dataclass
+class UserData:
+    id: int | None
+    github_id: int | None
+    github_username: str
+    email: str | None
+    avatar_url: str | None
+    role: str
+    is_active: bool
 
 
 @dataclass

--- a/backend/src/domain/services/api_metrics.py
+++ b/backend/src/domain/services/api_metrics.py
@@ -6,21 +6,27 @@ class ApiMetricsService:
     def __init__(self, repository: ApiCallRepository):
         self.repository = repository
 
-    def get_metrics(self, extractor_config_id: int | None = None) -> ApiCallMetricsData:
-        total = self.repository.count_total(extractor_config_id)
-        failures = self.repository.count_failures(extractor_config_id)
+    def get_metrics(
+        self, extractor_config_id: int | None = None, user_id: int | None = None
+    ) -> ApiCallMetricsData:
+        total = self.repository.count_total(extractor_config_id, user_id=user_id)
+        failures = self.repository.count_failures(extractor_config_id, user_id=user_id)
         error_rate = round((failures / total) * 100, 1) if total > 0 else 0.0
 
         error_breakdown = [
             {"error_type": error_type, "count": count}
-            for error_type, count in self.repository.count_by_error_type(extractor_config_id)
+            for error_type, count in self.repository.count_by_error_type(
+                extractor_config_id, user_id=user_id
+            )
         ]
 
         return ApiCallMetricsData(
             total_calls=total,
             total_failures=failures,
             error_rate=error_rate,
-            avg_response_time_ms=self.repository.avg_response_time_ms(extractor_config_id),
-            calls_this_week=self.repository.count_this_week(extractor_config_id),
+            avg_response_time_ms=self.repository.avg_response_time_ms(
+                extractor_config_id, user_id=user_id
+            ),
+            calls_this_week=self.repository.count_this_week(extractor_config_id, user_id=user_id),
             error_breakdown=error_breakdown,
         )

--- a/backend/src/domain/services/extractor_config.py
+++ b/backend/src/domain/services/extractor_config.py
@@ -4,10 +4,14 @@ from src.domain.entities import ExtractorConfigData, ExtractorConfigVersionData
 
 
 class ExtractorConfigRepo(Protocol):
-    def get_all(self, status: str | None = None) -> list[ExtractorConfigData]: ...
+    def get_all(
+        self, status: str | None = None, user_id: int | None = None
+    ) -> list[ExtractorConfigData]: ...
     def get_by_id(self, config_id: int) -> ExtractorConfigData | None: ...
     def get_default(self) -> ExtractorConfigData | None: ...
-    def create(self, data: ExtractorConfigData) -> ExtractorConfigData: ...
+    def create(
+        self, data: ExtractorConfigData, user_id: int | None = None
+    ) -> ExtractorConfigData: ...
     def update(self, config_id: int, data: ExtractorConfigData) -> ExtractorConfigData | None: ...
     def delete(self, config_id: int) -> bool: ...
     def get_versions(self, config_id: int) -> list[ExtractorConfigVersionData]: ...
@@ -17,8 +21,10 @@ class ExtractorConfigService:
     def __init__(self, repository: ExtractorConfigRepo):
         self.repository = repository
 
-    def get_all(self, status: str | None = None) -> list[ExtractorConfigData]:
-        return self.repository.get_all(status=status)
+    def get_all(
+        self, status: str | None = None, user_id: int | None = None
+    ) -> list[ExtractorConfigData]:
+        return self.repository.get_all(status=status, user_id=user_id)
 
     def get_by_id(self, config_id: int) -> ExtractorConfigData | None:
         return self.repository.get_by_id(config_id)
@@ -26,12 +32,12 @@ class ExtractorConfigService:
     def get_default(self) -> ExtractorConfigData | None:
         return self.repository.get_default()
 
-    def create(self, data: ExtractorConfigData) -> ExtractorConfigData:
+    def create(self, data: ExtractorConfigData, user_id: int | None = None) -> ExtractorConfigData:
         if data.status == "draft":
             data.is_default = False
         if data.is_default:
             self._clear_default()
-        return self.repository.create(data)
+        return self.repository.create(data, user_id=user_id)
 
     def update(self, config_id: int, data: ExtractorConfigData) -> ExtractorConfigData | None:
         if data.status == "draft":

--- a/backend/src/domain/services/metrics.py
+++ b/backend/src/domain/services/metrics.py
@@ -6,11 +6,13 @@ class MetricsService:
     def __init__(self, repository: ExtractionRepository):
         self.repository = repository
 
-    def get_metrics(self, extractor_config_id: int | None = None) -> MetricsData:
+    def get_metrics(
+        self, extractor_config_id: int | None = None, user_id: int | None = None
+    ) -> MetricsData:
         any_corrected, field_corrections, total = self.repository.count_corrections(
-            extractor_config_id
+            extractor_config_id, user_id=user_id
         )
-        this_week_count = self.repository.count_this_week(extractor_config_id)
+        this_week_count = self.repository.count_this_week(extractor_config_id, user_id=user_id)
 
         if total == 0:
             return MetricsData(

--- a/backend/src/domain/services/submission.py
+++ b/backend/src/domain/services/submission.py
@@ -12,6 +12,7 @@ class SubmissionService:
         submission: SubmissionData,
         extractor_config_id: int | None = None,
         extractor_config_version_id: int | None = None,
+        user_id: int | None = None,
     ) -> int:
         log_entry = ExtractionLog(
             filename=submission.filename,
@@ -19,19 +20,26 @@ class SubmissionService:
             final_fields=submission.final_fields,
             extractor_config_id=extractor_config_id,
             extractor_config_version_id=extractor_config_version_id,
+            user_id=user_id,
         )
 
         created_log = self.repository.create(log_entry)
         return int(created_log.id)  # type: ignore[arg-type]
 
     def get_extraction_logs(
-        self, page: int, page_size: int, extractor_config_id: int | None = None
+        self,
+        page: int,
+        page_size: int,
+        extractor_config_id: int | None = None,
+        user_id: int | None = None,
     ) -> tuple[list[ExtractionLog], int, int]:
         if page < 1:
             raise ValueError("Page must be >= 1")
         if page_size < 1 or page_size > 100:
             raise ValueError("Page size must be between 1 and 100")
 
-        logs, total = self.repository.get_all_paginated(page, page_size, extractor_config_id)
+        logs, total = self.repository.get_all_paginated(
+            page, page_size, extractor_config_id, user_id=user_id
+        )
         total_pages = (total + page_size - 1) // page_size
         return logs, total, total_pages

--- a/backend/src/infrastructure/api/admin/routes.py
+++ b/backend/src/infrastructure/api/admin/routes.py
@@ -1,0 +1,108 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from src.infrastructure.auth import AdminDep
+from src.infrastructure.database import get_db
+from src.infrastructure.repository import UserRepository
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+DbDep = Annotated[Session, Depends(get_db)]
+
+
+class CreateUserRequest(BaseModel):
+    github_username: str
+    role: str = "user"
+
+
+class UpdateUserRequest(BaseModel):
+    role: str | None = None
+    is_active: bool | None = None
+
+
+class UserResponse(BaseModel):
+    id: int
+    github_id: int | None
+    github_username: str
+    email: str | None
+    avatar_url: str | None
+    role: str
+    is_active: bool
+
+
+@router.get("/users", response_model=list[UserResponse])
+async def list_users(admin: AdminDep, db: DbDep):
+    repo = UserRepository(db)
+    users = repo.get_all()
+    return [
+        UserResponse(
+            id=u.id,
+            github_id=u.github_id,
+            github_username=u.github_username,
+            email=u.email,
+            avatar_url=u.avatar_url,
+            role=u.role,
+            is_active=u.is_active,
+        )
+        for u in users
+    ]
+
+
+@router.post("/users", response_model=UserResponse, status_code=201)
+async def create_user(request: CreateUserRequest, admin: AdminDep, db: DbDep):
+    repo = UserRepository(db)
+    existing = repo.get_by_github_username(request.github_username)
+    if existing:
+        raise HTTPException(status_code=409, detail="El usuario ya existe")
+    if request.role not in ("user", "admin"):
+        raise HTTPException(status_code=400, detail="Rol inválido")
+    user = repo.create(request.github_username, request.role)
+    return UserResponse(
+        id=user.id,
+        github_id=user.github_id,
+        github_username=user.github_username,
+        email=user.email,
+        avatar_url=user.avatar_url,
+        role=user.role,
+        is_active=user.is_active,
+    )
+
+
+@router.put("/users/{user_id}", response_model=UserResponse)
+async def update_user(user_id: int, request: UpdateUserRequest, admin: AdminDep, db: DbDep):
+    repo = UserRepository(db)
+    fields = {}
+    if request.role is not None:
+        if request.role not in ("user", "admin"):
+            raise HTTPException(status_code=400, detail="Rol inválido")
+        fields["role"] = request.role
+    if request.is_active is not None:
+        fields["is_active"] = request.is_active
+    if not fields:
+        raise HTTPException(status_code=400, detail="No se proporcionaron campos para actualizar")
+    user = repo.update(user_id, **fields)
+    if not user:
+        raise HTTPException(status_code=404, detail="Usuario no encontrado")
+    return UserResponse(
+        id=user.id,
+        github_id=user.github_id,
+        github_username=user.github_username,
+        email=user.email,
+        avatar_url=user.avatar_url,
+        role=user.role,
+        is_active=user.is_active,
+    )
+
+
+@router.delete("/users/{user_id}")
+async def delete_user(user_id: int, admin: AdminDep, db: DbDep):
+    if admin.id == user_id:
+        raise HTTPException(status_code=400, detail="No puedes eliminarte a ti mismo")
+    repo = UserRepository(db)
+    success = repo.delete(user_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Usuario no encontrado")
+    return {"message": "Usuario eliminado exitosamente"}

--- a/backend/src/infrastructure/api/auth/routes.py
+++ b/backend/src/infrastructure/api/auth/routes.py
@@ -1,0 +1,87 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from src.infrastructure.auth import UserDep, create_access_token, validate_github_token
+from src.infrastructure.database import get_db
+from src.infrastructure.repository import UserRepository
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+DbDep = Annotated[Session, Depends(get_db)]
+
+
+class LoginRequest(BaseModel):
+    github_access_token: str
+
+
+class LoginResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    user: "UserResponse"
+
+
+class UserResponse(BaseModel):
+    id: int
+    github_username: str
+    email: str | None
+    avatar_url: str | None
+    role: str
+
+
+@router.post("/login", response_model=LoginResponse)
+async def login(request: LoginRequest, db: DbDep):
+    github_profile = validate_github_token(request.github_access_token)
+
+    github_id = github_profile["id"]
+    github_username = github_profile["login"]
+    email = github_profile.get("email")
+    avatar_url = github_profile.get("avatar_url")
+
+    repo = UserRepository(db)
+
+    # Try by github_id first (returning user), then by username (first login)
+    user = repo.get_by_github_id(github_id)
+    if not user:
+        user = repo.get_by_github_username(github_username)
+        if not user:
+            raise HTTPException(
+                status_code=403,
+                detail="Usuario no registrado. Contacta al administrador.",
+            )
+        # First login — fill in github_id and profile info
+        repo.update_login_info(user.id, github_id, email, avatar_url)
+        user = repo.get_by_id(user.id)
+    else:
+        # Update last_login and profile info
+        repo.update_login_info(user.id, github_id, email, avatar_url)
+        user = repo.get_by_id(user.id)
+
+    if not user.is_active:
+        raise HTTPException(status_code=403, detail="Usuario desactivado")
+
+    token = create_access_token(user)
+
+    return LoginResponse(
+        access_token=token,
+        user=UserResponse(
+            id=user.id,
+            github_username=user.github_username,
+            email=user.email,
+            avatar_url=user.avatar_url,
+            role=user.role,
+        ),
+    )
+
+
+@router.get("/me", response_model=UserResponse)
+async def get_me(user: UserDep):
+    return UserResponse(
+        id=user.id,
+        github_username=user.github_username,
+        email=user.email,
+        avatar_url=user.avatar_url,
+        role=user.role,
+    )

--- a/backend/src/infrastructure/api/extraction/routes.py
+++ b/backend/src/infrastructure/api/extraction/routes.py
@@ -31,6 +31,7 @@ from src.infrastructure.api.extraction.dtos import (
     UploadUrlRequest,
     UploadUrlResponse,
 )
+from src.infrastructure.auth import UserDep
 from src.infrastructure.database import get_db
 from src.infrastructure.repository import (
     ApiCallRepository,
@@ -89,7 +90,7 @@ def _select_variant(
 
 
 @router.post("/upload-url", response_model=UploadUrlResponse)
-async def get_upload_url(request: UploadUrlRequest):
+async def get_upload_url(request: UploadUrlRequest, user: UserDep):
     """Return an S3 key and presigned upload URL (None when S3 is not configured)."""
     if not request.filename:
         raise HTTPException(status_code=400, detail="No se proporcionó un nombre de archivo")
@@ -100,7 +101,7 @@ async def get_upload_url(request: UploadUrlRequest):
 
 
 @router.post("/upload")
-async def upload_file(file: Annotated[UploadFile, File()]):
+async def upload_file(file: Annotated[UploadFile, File()], user: UserDep):
     """Fallback upload through backend (used when S3 presigned URLs are not available)."""
     if not file.filename:
         raise HTTPException(status_code=400, detail="No se proporcionó un archivo")
@@ -112,7 +113,7 @@ async def upload_file(file: Annotated[UploadFile, File()]):
 
 
 @router.post("/extract", response_model=ExtractionResponse)
-async def extract_from_file(request: ExtractRequest, db: DbDep):
+async def extract_from_file(request: ExtractRequest, db: DbDep, user: UserDep):
     api_repo = ApiCallRepository(db)
     config_data = _load_config(db, request.extractor_config_id)
 
@@ -136,6 +137,7 @@ async def extract_from_file(request: ExtractRequest, db: DbDep):
             filename=request.filename,
             extractor_config_id=request.extractor_config_id,
             extractor_config_version_id=version_id,
+            user_id=user.id,
         )
 
         # Determine extractor config info for the response
@@ -161,6 +163,7 @@ async def extract_from_file(request: ExtractRequest, db: DbDep):
             filename=request.filename,
             extractor_config_id=request.extractor_config_id,
             extractor_config_version_id=version_id,
+            user_id=user.id,
         )
         if e.call_result.error_type == "InvalidDocument":
             raise HTTPException(status_code=400, detail=str(e))
@@ -174,7 +177,7 @@ async def extract_from_file(request: ExtractRequest, db: DbDep):
 
 
 @router.post("/submit", response_model=SubmissionResponse)
-async def submit_extraction(submission: SubmissionRequest, db: DbDep):
+async def submit_extraction(submission: SubmissionRequest, db: DbDep, user: UserDep):
     try:
         service = SubmissionService(_get_repository(db))
 
@@ -188,6 +191,7 @@ async def submit_extraction(submission: SubmissionRequest, db: DbDep):
             submission_data,
             submission.extractor_config_id,
             submission.extractor_config_version_id,
+            user_id=user.id,
         )
 
         return SubmissionResponse(message="Submission recorded successfully", id=log_id)
@@ -204,11 +208,18 @@ async def get_banks():
 
 @router.get("/logs", response_model=LogsResponse)
 async def get_extraction_logs(
-    db: DbDep, page: int = 1, page_size: int = 50, extractor_config_id: int | None = None
+    db: DbDep,
+    user: UserDep,
+    page: int = 1,
+    page_size: int = 50,
+    extractor_config_id: int | None = None,
 ):
     try:
+        user_filter = None if user.role == "admin" else user.id
         service = SubmissionService(_get_repository(db))
-        logs, total, total_pages = service.get_extraction_logs(page, page_size, extractor_config_id)
+        logs, total, total_pages = service.get_extraction_logs(
+            page, page_size, extractor_config_id, user_id=user_filter
+        )
 
         logs_data = [ExtractionLogResponse.model_validate(log) for log in logs]
 
@@ -228,10 +239,11 @@ async def get_extraction_logs(
 
 
 @router.get("/metrics", response_model=MetricsResponse)
-async def get_metrics(db: DbDep, extractor_config_id: int | None = None):
+async def get_metrics(db: DbDep, user: UserDep, extractor_config_id: int | None = None):
     try:
+        user_filter = None if user.role == "admin" else user.id
         service = MetricsService(_get_repository(db))
-        metrics = service.get_metrics(extractor_config_id=extractor_config_id)
+        metrics = service.get_metrics(extractor_config_id=extractor_config_id, user_id=user_filter)
 
         return MetricsResponse.model_validate(metrics)
     except Exception as e:
@@ -239,10 +251,11 @@ async def get_metrics(db: DbDep, extractor_config_id: int | None = None):
 
 
 @router.get("/api-metrics", response_model=ApiCallMetricsResponse)
-async def get_api_metrics(db: DbDep, extractor_config_id: int | None = None):
+async def get_api_metrics(db: DbDep, user: UserDep, extractor_config_id: int | None = None):
     try:
+        user_filter = None if user.role == "admin" else user.id
         service = ApiMetricsService(ApiCallRepository(db))
-        metrics = service.get_metrics(extractor_config_id=extractor_config_id)
+        metrics = service.get_metrics(extractor_config_id=extractor_config_id, user_id=user_filter)
 
         return ApiCallMetricsResponse(
             total_calls=metrics.total_calls,

--- a/backend/src/infrastructure/api/extractors/routes.py
+++ b/backend/src/infrastructure/api/extractors/routes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from src.core.logger import get_logger
-from src.domain.entities import ExtractorConfigData
+from src.domain.entities import ExtractorConfigData, UserData
 from src.domain.services.extractor_config import ExtractorConfigService
 
 logger = get_logger(__name__)
@@ -33,6 +33,7 @@ from src.infrastructure.api.extraction.dtos import (
     TestExtractResponse,
     UpdatePromptRequest,
 )
+from src.infrastructure.auth import UserDep
 from src.infrastructure.database import get_db
 from src.infrastructure.extractors.statement_extractor import (
     SUPPORTED_EXTENSIONS,
@@ -74,22 +75,28 @@ def _get_service(db: Session) -> ExtractorConfigService:
     return ExtractorConfigService(ExtractorConfigRepository(db))
 
 
+def _check_ownership(config: ExtractorConfigData, user: UserData) -> None:
+    if user.role != "admin" and config.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Extractor config not found")
+
+
 @router.get("", response_model=ExtractorConfigListResponse)
-async def list_extractor_configs(db: DbDep, status: str | None = None):
+async def list_extractor_configs(db: DbDep, user: UserDep, status: str | None = None):
+    user_filter = None if user.role == "admin" else user.id
     service = _get_service(db)
-    configs = service.get_all(status=status)
+    configs = service.get_all(status=status, user_id=user_filter)
     return ExtractorConfigListResponse(
         configs=[ExtractorConfigResponse.model_validate(c) for c in configs]
     )
 
 
 @router.get("/models", response_model=list[ModelInfo])
-async def get_available_models():
+async def get_available_models(user: UserDep):
     return AVAILABLE_MODELS
 
 
 @router.post("/generate-schema", response_model=GenerateSchemaResponse)
-async def generate_schema(request: GenerateSchemaRequest):
+async def generate_schema(request: GenerateSchemaRequest, user: UserDep):
     try:
         schema = generate_schema_from_description(request.description)
         return GenerateSchemaResponse(output_schema=schema)
@@ -98,7 +105,7 @@ async def generate_schema(request: GenerateSchemaRequest):
 
 
 @router.post("/generate-prompt", response_model=GeneratePromptResponse)
-async def generate_prompt(request: GeneratePromptRequest):
+async def generate_prompt(request: GeneratePromptRequest, user: UserDep):
     try:
         prompt = generate_prompt_from_schema(request.output_schema, request.document_type)
         return GeneratePromptResponse(prompt=prompt)
@@ -107,7 +114,7 @@ async def generate_prompt(request: GeneratePromptRequest):
 
 
 @router.post("/update-prompt", response_model=GeneratePromptResponse)
-async def update_prompt(request: UpdatePromptRequest):
+async def update_prompt(request: UpdatePromptRequest, user: UserDep):
     try:
         prompt = update_prompt_with_instructions(
             request.current_prompt, request.instructions, request.output_schema
@@ -118,7 +125,7 @@ async def update_prompt(request: UpdatePromptRequest):
 
 
 @router.post("/test-extract", response_model=TestExtractResponse)
-async def test_extract(request: TestExtractRequest, db: DbDep):
+async def test_extract(request: TestExtractRequest, db: DbDep, user: UserDep):
     config_data = request.config
     logger.info("=== Test extract request ===")
     logger.info("Filename: %s, S3 key: %s", request.filename, request.s3_key)
@@ -178,6 +185,7 @@ async def test_extract(request: TestExtractRequest, db: DbDep):
             success=True,
             response_time_ms=elapsed_ms,
             extractor_config_id=request.extractor_config_id,
+            user_id=user.id,
         )
 
         return TestExtractResponse(fields=result, response_time_ms=elapsed_ms, test_log_id=log.id)
@@ -198,6 +206,7 @@ async def test_extract(request: TestExtractRequest, db: DbDep):
                 error_message=str(e),
                 response_time_ms=elapsed_ms,
                 extractor_config_id=request.extractor_config_id,
+                user_id=user.id,
             )
         except Exception:
             pass
@@ -208,33 +217,40 @@ async def test_extract(request: TestExtractRequest, db: DbDep):
 
 
 @router.get("/{config_id}/test-logs", response_model=list[TestExtractionLogResponse])
-async def get_test_logs(config_id: int, db: DbDep):
+async def get_test_logs(config_id: int, db: DbDep, user: UserDep):
+    service = _get_service(db)
+    config = service.get_by_id(config_id)
+    if not config:
+        raise HTTPException(status_code=404, detail="Extractor config not found")
+    _check_ownership(config, user)
     test_log_repo = TestExtractionLogRepository(db)
     logs = test_log_repo.get_by_config_id(config_id)
     return [TestExtractionLogResponse.model_validate(log) for log in logs]
 
 
 @router.get("/{config_id}", response_model=ExtractorConfigResponse)
-async def get_extractor_config(config_id: int, db: DbDep):
+async def get_extractor_config(config_id: int, db: DbDep, user: UserDep):
     service = _get_service(db)
     config = service.get_by_id(config_id)
     if not config:
         raise HTTPException(status_code=404, detail="Extractor config not found")
+    _check_ownership(config, user)
     return ExtractorConfigResponse.model_validate(config)
 
 
 @router.get("/{config_id}/versions", response_model=list[ExtractorConfigVersionResponse])
-async def get_extractor_versions(config_id: int, db: DbDep):
+async def get_extractor_versions(config_id: int, db: DbDep, user: UserDep):
     service = _get_service(db)
     config = service.get_by_id(config_id)
     if not config:
         raise HTTPException(status_code=404, detail="Extractor config not found")
+    _check_ownership(config, user)
     versions = service.get_versions(config_id)
     return [ExtractorConfigVersionResponse.model_validate(v) for v in versions]
 
 
 @router.post("", response_model=ExtractorConfigResponse, status_code=201)
-async def create_extractor_config(request: ExtractorConfigCreateRequest, db: DbDep):
+async def create_extractor_config(request: ExtractorConfigCreateRequest, db: DbDep, user: UserDep):
     service = _get_service(db)
     data = ExtractorConfigData(
         id=None,
@@ -246,16 +262,19 @@ async def create_extractor_config(request: ExtractorConfigCreateRequest, db: DbD
         is_default=request.is_default,
         status=request.status,
     )
-    config = service.create(data)
+    config = service.create(data, user_id=user.id)
     return ExtractorConfigResponse.model_validate(config)
 
 
 @router.put("/{config_id}", response_model=ExtractorConfigResponse)
-async def update_extractor_config(config_id: int, request: ExtractorConfigUpdateRequest, db: DbDep):
+async def update_extractor_config(
+    config_id: int, request: ExtractorConfigUpdateRequest, db: DbDep, user: UserDep
+):
     service = _get_service(db)
     existing = service.get_by_id(config_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Extractor config not found")
+    _check_ownership(existing, user)
 
     data = ExtractorConfigData(
         id=config_id,
@@ -276,11 +295,12 @@ async def update_extractor_config(config_id: int, request: ExtractorConfigUpdate
 
 
 @router.delete("/{config_id}")
-async def delete_extractor_config(config_id: int, db: DbDep):
+async def delete_extractor_config(config_id: int, db: DbDep, user: UserDep):
     service = _get_service(db)
     existing = service.get_by_id(config_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Extractor config not found")
+    _check_ownership(existing, user)
     if existing.is_default:
         raise HTTPException(status_code=400, detail="No se puede eliminar el extractor por defecto")
     success = service.delete(config_id)
@@ -294,12 +314,13 @@ async def delete_extractor_config(config_id: int, db: DbDep):
     response_model=ExtractorConfigVersionResponse,
 )
 async def toggle_version_active(
-    config_id: int, version_id: int, request: SetActiveRequest, db: DbDep
+    config_id: int, version_id: int, request: SetActiveRequest, db: DbDep, user: UserDep
 ):
     repo = ExtractorConfigRepository(db)
     config = repo.get_by_id(config_id)
     if not config:
         raise HTTPException(status_code=404, detail="Extractor config no encontrado")
+    _check_ownership(config, user)
 
     # Find the version and verify it belongs to this config
     versions = repo.get_versions(config_id)

--- a/backend/src/infrastructure/auth.py
+++ b/backend/src/infrastructure/auth.py
@@ -1,0 +1,81 @@
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Annotated
+
+import jwt
+import requests
+from fastapi import Depends, Header, HTTPException
+from sqlalchemy.orm import Session
+
+from src.domain.entities import UserData
+from src.infrastructure.database import get_db
+from src.infrastructure.repository import UserRepository
+
+JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret-change-in-production")
+JWT_ALGORITHM = "HS256"
+JWT_EXPIRY_HOURS = 24
+
+
+def create_access_token(user: UserData) -> str:
+    payload = {
+        "user_id": user.id,
+        "role": user.role,
+        "exp": datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRY_HOURS),
+        "iat": datetime.now(timezone.utc),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+
+def validate_github_token(github_access_token: str) -> dict:
+    try:
+        response = requests.get(
+            "https://api.github.com/user",
+            headers={"Authorization": f"Bearer {github_access_token}"},
+            timeout=10,
+        )
+    except requests.RequestException:
+        raise HTTPException(
+            status_code=502, detail="No se pudo conectar con GitHub para validar el token"
+        )
+    if response.status_code != 200:
+        raise HTTPException(status_code=401, detail="Token de GitHub inválido")
+    return response.json()
+
+
+def get_current_user(
+    authorization: Annotated[str, Header()],
+    db: Annotated[Session, Depends(get_db)],
+) -> UserData:
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Token inválido")
+
+    token = authorization[7:]
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expirado")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Token inválido")
+
+    user_id = payload.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Token inválido")
+
+    repo = UserRepository(db)
+    user = repo.get_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="Usuario no encontrado")
+    if not user.is_active:
+        raise HTTPException(status_code=403, detail="Usuario desactivado")
+
+    return user
+
+
+def get_admin_user(user: UserData = Depends(get_current_user)) -> UserData:
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Se requieren permisos de administrador")
+    return user
+
+
+UserDep = Annotated[UserData, Depends(get_current_user)]
+AdminDep = Annotated[UserData, Depends(get_admin_user)]

--- a/backend/src/infrastructure/models.py
+++ b/backend/src/infrastructure/models.py
@@ -1,22 +1,48 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
 
 
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    github_id = Column(Integer, unique=True, nullable=True, index=True)
+    github_username = Column(String(100), unique=True, nullable=False)
+    email = Column(String(255), nullable=True)
+    avatar_url = Column(String(500), nullable=True)
+    role = Column(String(20), nullable=False, default="user")
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    last_login_at = Column(DateTime, nullable=True)
+
+
 class ExtractorConfig(Base):
     __tablename__ = "extractor_configs"
+    __table_args__ = (UniqueConstraint("name", "user_id", name="uq_extractor_configs_name_user"),)
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(200), unique=True, nullable=False)
+    name = Column(String(200), nullable=False)
     description = Column(String(500), nullable=True)
     prompt = Column(Text, nullable=False)
     model = Column(String(100), nullable=False, default="claude-haiku-4-5-20251001")
     output_schema = Column(JSON, nullable=False)
     is_default = Column(Boolean, default=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     status = Column(String(20), nullable=False, default="active")
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(
@@ -49,6 +75,7 @@ class ExtractionLog(Base):
     extracted_fields = Column(JSON, default=dict)
     final_fields = Column(JSON, default=dict)
 
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     extractor_config_id = Column(Integer, ForeignKey("extractor_configs.id"), nullable=True)
     extractor_config_version_id = Column(
         Integer, ForeignKey("extractor_config_versions.id"), nullable=True
@@ -73,6 +100,7 @@ class TestExtractionLog(Base):
     timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
     filename = Column(String, nullable=False)
     s3_key = Column(String, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     extractor_config_id = Column(
         Integer, ForeignKey("extractor_configs.id", ondelete="SET NULL"), nullable=True
     )
@@ -90,6 +118,7 @@ class ApiCallLog(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     model = Column(String, nullable=False)
     success = Column(Boolean, nullable=False)
     error_type = Column(String, nullable=True)

--- a/backend/src/infrastructure/repository.py
+++ b/backend/src/infrastructure/repository.py
@@ -3,13 +3,19 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from src.domain.entities import ApiCallResult, ExtractorConfigData, ExtractorConfigVersionData
+from src.domain.entities import (
+    ApiCallResult,
+    ExtractorConfigData,
+    ExtractorConfigVersionData,
+    UserData,
+)
 from src.infrastructure.models import (
     ApiCallLog,
     ExtractionLog,
     ExtractorConfig,
     ExtractorConfigVersion,
     TestExtractionLog,
+    User,
 )
 
 
@@ -17,16 +23,22 @@ class ExtractionRepository:
     def __init__(self, session: Session):
         self.session = session
 
-    def _base_query(self, extractor_config_id: int | None = None):
+    def _base_query(self, extractor_config_id: int | None = None, user_id: int | None = None):
         q = self.session.query(ExtractionLog)
+        if user_id is not None:
+            q = q.filter(ExtractionLog.user_id == user_id)
         if extractor_config_id is not None:
             q = q.filter(ExtractionLog.extractor_config_id == extractor_config_id)
         return q
 
     def get_all_paginated(
-        self, page: int, page_size: int, extractor_config_id: int | None = None
+        self,
+        page: int,
+        page_size: int,
+        extractor_config_id: int | None = None,
+        user_id: int | None = None,
     ) -> tuple[list[ExtractionLog], int]:
-        q = self._base_query(extractor_config_id)
+        q = self._base_query(extractor_config_id, user_id=user_id)
         total = q.count()
         offset = (page - 1) * page_size
         logs = q.order_by(ExtractionLog.timestamp.desc()).offset(offset).limit(page_size).all()
@@ -41,17 +53,21 @@ class ExtractionRepository:
         self.session.refresh(log_entry)
         return log_entry
 
-    def count_total(self, extractor_config_id: int | None = None) -> int:
+    def count_total(
+        self, extractor_config_id: int | None = None, user_id: int | None = None
+    ) -> int:
         q = self.session.query(func.count(ExtractionLog.id))
+        if user_id is not None:
+            q = q.filter(ExtractionLog.user_id == user_id)
         if extractor_config_id is not None:
             q = q.filter(ExtractionLog.extractor_config_id == extractor_config_id)
         return q.scalar() or 0
 
     def count_corrections(
-        self, extractor_config_id: int | None = None
+        self, extractor_config_id: int | None = None, user_id: int | None = None
     ) -> tuple[int, dict[str, int], int]:
         """Returns (any_corrected_count, {field: correction_count}, total)."""
-        q = self._base_query(extractor_config_id)
+        q = self._base_query(extractor_config_id, user_id=user_id)
         total = q.count()
         field_corrections: dict[str, int] = {}
         any_corrected = 0
@@ -68,11 +84,15 @@ class ExtractionRepository:
 
         return any_corrected, field_corrections, total
 
-    def count_this_week(self, extractor_config_id: int | None = None) -> int:
+    def count_this_week(
+        self, extractor_config_id: int | None = None, user_id: int | None = None
+    ) -> int:
         week_ago = datetime.now(timezone.utc) - timedelta(days=7)
         q = self.session.query(func.count(ExtractionLog.id)).filter(
             ExtractionLog.timestamp >= week_ago
         )
+        if user_id is not None:
+            q = q.filter(ExtractionLog.user_id == user_id)
         if extractor_config_id is not None:
             q = q.filter(ExtractionLog.extractor_config_id == extractor_config_id)
         return q.scalar() or 0
@@ -93,6 +113,7 @@ class ExtractorConfigRepository:
             output_schema=config.output_schema,
             is_default=config.is_default,
             status=config.status,
+            user_id=config.user_id,
             created_at=config.created_at,
             updated_at=config.updated_at,
         )
@@ -110,8 +131,12 @@ class ExtractorConfigRepository:
             created_at=version.created_at,
         )
 
-    def get_all(self, status: str | None = None) -> list[ExtractorConfigData]:
+    def get_all(
+        self, status: str | None = None, user_id: int | None = None
+    ) -> list[ExtractorConfigData]:
         q = self.session.query(ExtractorConfig)
+        if user_id is not None:
+            q = q.filter(ExtractorConfig.user_id == user_id)
         if status is not None:
             q = q.filter(ExtractorConfig.status == status)
         configs = q.order_by(ExtractorConfig.id).all()
@@ -130,7 +155,7 @@ class ExtractorConfigRepository:
         )
         return self._to_entity(config) if config else None
 
-    def create(self, data: ExtractorConfigData) -> ExtractorConfigData:
+    def create(self, data: ExtractorConfigData, user_id: int | None = None) -> ExtractorConfigData:
         config = ExtractorConfig(
             name=data.name,
             description=data.description,
@@ -139,6 +164,7 @@ class ExtractorConfigRepository:
             output_schema=data.output_schema,
             is_default=data.is_default,
             status=data.status,
+            user_id=user_id,
         )
         self.session.add(config)
         self.session.commit()
@@ -267,6 +293,7 @@ class ApiCallRepository:
         filename: str | None = None,
         extractor_config_id: int | None = None,
         extractor_config_version_id: int | None = None,
+        user_id: int | None = None,
     ) -> ApiCallLog:
         log = ApiCallLog(
             model=call_result.model,
@@ -277,45 +304,53 @@ class ApiCallRepository:
             filename=filename,
             extractor_config_id=extractor_config_id,
             extractor_config_version_id=extractor_config_version_id,
+            user_id=user_id,
         )
         self.session.add(log)
         self.session.commit()
         self.session.refresh(log)
         return log
 
-    def count_total(self, extractor_config_id: int | None = None) -> int:
+    def _filtered(self, q, extractor_config_id: int | None, user_id: int | None):
+        if user_id is not None:
+            q = q.filter(ApiCallLog.user_id == user_id)
+        if extractor_config_id is not None:
+            q = q.filter(ApiCallLog.extractor_config_id == extractor_config_id)
+        return q
+
+    def count_total(
+        self, extractor_config_id: int | None = None, user_id: int | None = None
+    ) -> int:
         q = self.session.query(func.count(ApiCallLog.id))
-        if extractor_config_id is not None:
-            q = q.filter(ApiCallLog.extractor_config_id == extractor_config_id)
-        return q.scalar() or 0
+        return self._filtered(q, extractor_config_id, user_id).scalar() or 0
 
-    def count_failures(self, extractor_config_id: int | None = None) -> int:
+    def count_failures(
+        self, extractor_config_id: int | None = None, user_id: int | None = None
+    ) -> int:
         q = self.session.query(func.count(ApiCallLog.id)).filter(ApiCallLog.success.is_(False))
-        if extractor_config_id is not None:
-            q = q.filter(ApiCallLog.extractor_config_id == extractor_config_id)
-        return q.scalar() or 0
+        return self._filtered(q, extractor_config_id, user_id).scalar() or 0
 
-    def count_by_error_type(self, extractor_config_id: int | None = None) -> list[tuple[str, int]]:
+    def count_by_error_type(
+        self, extractor_config_id: int | None = None, user_id: int | None = None
+    ) -> list[tuple[str, int]]:
         q = self.session.query(ApiCallLog.error_type, func.count(ApiCallLog.id)).filter(
             ApiCallLog.error_type.isnot(None)
         )
-        if extractor_config_id is not None:
-            q = q.filter(ApiCallLog.extractor_config_id == extractor_config_id)
-        return q.group_by(ApiCallLog.error_type).all()
+        return self._filtered(q, extractor_config_id, user_id).group_by(ApiCallLog.error_type).all()
 
-    def avg_response_time_ms(self, extractor_config_id: int | None = None) -> float:
+    def avg_response_time_ms(
+        self, extractor_config_id: int | None = None, user_id: int | None = None
+    ) -> float:
         q = self.session.query(func.avg(ApiCallLog.response_time_ms))
-        if extractor_config_id is not None:
-            q = q.filter(ApiCallLog.extractor_config_id == extractor_config_id)
-        result = q.scalar()
+        result = self._filtered(q, extractor_config_id, user_id).scalar()
         return round(result, 1) if result else 0.0
 
-    def count_this_week(self, extractor_config_id: int | None = None) -> int:
+    def count_this_week(
+        self, extractor_config_id: int | None = None, user_id: int | None = None
+    ) -> int:
         week_ago = datetime.now(timezone.utc) - timedelta(days=7)
         q = self.session.query(func.count(ApiCallLog.id)).filter(ApiCallLog.timestamp >= week_ago)
-        if extractor_config_id is not None:
-            q = q.filter(ApiCallLog.extractor_config_id == extractor_config_id)
-        return q.scalar() or 0
+        return self._filtered(q, extractor_config_id, user_id).scalar() or 0
 
 
 class TestExtractionLogRepository:
@@ -334,6 +369,7 @@ class TestExtractionLogRepository:
         response_time_ms: float,
         error_message: str | None = None,
         extractor_config_id: int | None = None,
+        user_id: int | None = None,
     ) -> TestExtractionLog:
         log = TestExtractionLog(
             filename=filename,
@@ -346,6 +382,7 @@ class TestExtractionLogRepository:
             success=success,
             error_message=error_message,
             response_time_ms=response_time_ms,
+            user_id=user_id,
         )
         self.session.add(log)
         self.session.commit()
@@ -359,3 +396,76 @@ class TestExtractionLogRepository:
             .order_by(TestExtractionLog.timestamp.desc())
             .all()
         )
+
+
+class UserRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    @staticmethod
+    def _to_entity(user: User) -> UserData:
+        return UserData(
+            id=user.id,
+            github_id=user.github_id,
+            github_username=user.github_username,
+            email=user.email,
+            avatar_url=user.avatar_url,
+            role=user.role,
+            is_active=user.is_active,
+        )
+
+    def get_by_github_id(self, github_id: int) -> UserData | None:
+        user = self.session.query(User).filter(User.github_id == github_id).first()
+        return self._to_entity(user) if user else None
+
+    def get_by_github_username(self, username: str) -> UserData | None:
+        user = self.session.query(User).filter(User.github_username == username).first()
+        return self._to_entity(user) if user else None
+
+    def get_by_id(self, user_id: int) -> UserData | None:
+        user = self.session.query(User).filter(User.id == user_id).first()
+        return self._to_entity(user) if user else None
+
+    def get_all(self) -> list[UserData]:
+        users = self.session.query(User).order_by(User.id).all()
+        return [self._to_entity(u) for u in users]
+
+    def create(self, github_username: str, role: str = "user") -> UserData:
+        user = User(github_username=github_username, role=role)
+        self.session.add(user)
+        self.session.commit()
+        self.session.refresh(user)
+        return self._to_entity(user)
+
+    def update(self, user_id: int, **fields: object) -> UserData | None:
+        user = self.session.query(User).filter(User.id == user_id).first()
+        if not user:
+            return None
+        for key, value in fields.items():
+            if hasattr(user, key):
+                setattr(user, key, value)
+        self.session.commit()
+        self.session.refresh(user)
+        return self._to_entity(user)
+
+    def update_login_info(
+        self, user_id: int, github_id: int, email: str | None, avatar_url: str | None
+    ) -> UserData | None:
+        user = self.session.query(User).filter(User.id == user_id).first()
+        if not user:
+            return None
+        user.github_id = github_id
+        user.email = email
+        user.avatar_url = avatar_url
+        user.last_login_at = datetime.now(timezone.utc)
+        self.session.commit()
+        self.session.refresh(user)
+        return self._to_entity(user)
+
+    def delete(self, user_id: int) -> bool:
+        user = self.session.query(User).filter(User.id == user_id).first()
+        if not user:
+            return False
+        self.session.delete(user)
+        self.session.commit()
+        return True

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -14,6 +14,8 @@ from fastapi.responses import JSONResponse
 
 from alembic import command
 from src.core.logger import get_logger
+from src.infrastructure.api.admin.routes import router as admin_router
+from src.infrastructure.api.auth.routes import router as auth_router
 from src.infrastructure.api.extraction.routes import router as extraction_router
 from src.infrastructure.api.extractors.routes import router as extractors_router
 from src.infrastructure.storage import get_storage
@@ -52,6 +54,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(auth_router)
+app.include_router(admin_router)
 app.include_router(extraction_router)
 app.include_router(extractors_router)
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -89,6 +89,7 @@ dependencies = [
     { name = "pillow" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
+    { name = "pyjwt" },
     { name = "pytesseract" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -117,6 +118,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
+    { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "pytesseract", specifier = ">=0.3.10" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
@@ -1147,6 +1149,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { useUsers, useCreateUser, useUpdateUser, useDeleteUser } from "@/lib/hooks";
+import { useExtractionStore } from "@/lib/store";
+import { useRouter } from "next/navigation";
+
+export default function AdminUsersPage() {
+  const router = useRouter();
+  const backendUser = useExtractionStore((s) => s.backendUser);
+  const { data: users, isLoading, error } = useUsers();
+  const createUserMutation = useCreateUser();
+  const updateUserMutation = useUpdateUser();
+  const deleteUserMutation = useDeleteUser();
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newUsername, setNewUsername] = useState("");
+  const [newRole, setNewRole] = useState("user");
+
+  // Redirect non-admins
+  if (backendUser && backendUser.role !== "admin") {
+    router.push("/");
+    return null;
+  }
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newUsername.trim()) return;
+    try {
+      await createUserMutation.mutateAsync({ github_username: newUsername.trim(), role: newRole });
+      setNewUsername("");
+      setNewRole("user");
+      setShowCreateForm(false);
+    } catch {
+      // error is shown via mutation state
+    }
+  };
+
+  const handleToggleActive = async (userId: number, currentActive: boolean) => {
+    await updateUserMutation.mutateAsync({ id: userId, data: { is_active: !currentActive } });
+  };
+
+  const handleChangeRole = async (userId: number, newRole: string) => {
+    await updateUserMutation.mutateAsync({ id: userId, data: { role: newRole } });
+  };
+
+  const handleDelete = async (userId: number, username: string) => {
+    if (!confirm(`¿Eliminar al usuario ${username}? Esta acción no se puede deshacer.`)) return;
+    await deleteUserMutation.mutateAsync(userId);
+  };
+
+  return (
+    <div className="p-8">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Gestión de Usuarios</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Administra los usuarios que tienen acceso al sistema
+          </p>
+        </div>
+        <button
+          onClick={() => setShowCreateForm(true)}
+          className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+        >
+          Crear usuario
+        </button>
+      </div>
+
+      {createUserMutation.error && (
+        <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+          {createUserMutation.error.message}
+        </div>
+      )}
+
+      {showCreateForm && (
+        <div className="mb-6 rounded-lg border border-gray-200 bg-white p-4">
+          <h3 className="mb-3 text-sm font-medium text-gray-900">Nuevo usuario</h3>
+          <form onSubmit={handleCreate} className="flex items-end gap-3">
+            <div className="flex-1">
+              <label className="block text-xs font-medium text-gray-700">
+                Username de GitHub
+              </label>
+              <input
+                type="text"
+                value={newUsername}
+                onChange={(e) => setNewUsername(e.target.value)}
+                placeholder="username"
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700">Rol</label>
+              <select
+                value={newRole}
+                onChange={(e) => setNewRole(e.target.value)}
+                className="mt-1 block rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500"
+              >
+                <option value="user">Usuario</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+            <button
+              type="submit"
+              disabled={createUserMutation.isPending}
+              className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50"
+            >
+              {createUserMutation.isPending ? "Creando..." : "Crear"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowCreateForm(false)}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              Cancelar
+            </button>
+          </form>
+        </div>
+      )}
+
+      {isLoading && <p className="text-sm text-gray-500">Cargando usuarios...</p>}
+      {error && <p className="text-sm text-red-600">Error al cargar usuarios</p>}
+
+      {users && (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Usuario
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Email
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Rol
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Estado
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Acciones
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {users.map((user) => (
+                <tr key={user.id}>
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <div className="flex items-center gap-3">
+                      {user.avatar_url && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={user.avatar_url}
+                          alt={user.github_username}
+                          className="h-8 w-8 rounded-full"
+                        />
+                      )}
+                      <span className="text-sm font-medium text-gray-900">
+                        {user.github_username}
+                      </span>
+                    </div>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                    {user.email || "—"}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <select
+                      value={user.role}
+                      onChange={(e) => handleChangeRole(user.id, e.target.value)}
+                      disabled={user.id === backendUser?.id}
+                      className="rounded border border-gray-300 px-2 py-1 text-xs disabled:opacity-50"
+                    >
+                      <option value="user">Usuario</option>
+                      <option value="admin">Admin</option>
+                    </select>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <button
+                      onClick={() => handleToggleActive(user.id, user.is_active)}
+                      disabled={user.id === backendUser?.id}
+                      className="disabled:opacity-50"
+                    >
+                      <span
+                        className={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
+                          user.is_active
+                            ? "bg-green-100 text-green-800"
+                            : "bg-red-100 text-red-800"
+                        }`}
+                      >
+                        {user.is_active ? "Activo" : "Inactivo"}
+                      </span>
+                    </button>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    {user.id !== backendUser?.id && (
+                      <button
+                        onClick={() => handleDelete(user.id, user.github_username)}
+                        className="text-red-600 hover:text-red-800"
+                      >
+                        Eliminar
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import { Sidebar } from "@/components/sidebar";
 import { QueryProvider } from "@/lib/query-provider";
+import { AuthProvider } from "@/components/auth-provider";
+import { AppShell } from "@/components/app-shell";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -19,12 +20,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <QueryProvider>
-          <div className="flex h-screen overflow-hidden">
-            <Sidebar />
-            <main className="flex-1 overflow-auto">{children}</main>
-          </div>
-        </QueryProvider>
+        <AuthProvider>
+          <QueryProvider>
+            <AppShell>{children}</AppShell>
+          </QueryProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { useState, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+
+function ErrorMessage() {
+  const searchParams = useSearchParams();
+  const error = searchParams.get("error");
+
+  if (!error) return null;
+
+  return (
+    <div className="rounded-md bg-red-50 p-4">
+      <p className="text-sm text-red-700">
+        {error === "AccessDenied"
+          ? "Usuario no registrado. Contacta al administrador para obtener acceso."
+          : "Error al iniciar sesión. Intenta de nuevo."}
+      </p>
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLogin = async () => {
+    setIsLoading(true);
+    await signIn("github", { callbackUrl: "/" });
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md space-y-8 rounded-lg bg-white p-8 shadow-lg">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-gray-900">Bank Extraction</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            Inicia sesión para acceder al sistema
+          </p>
+        </div>
+
+        <Suspense>
+          <ErrorMessage />
+        </Suspense>
+
+        <button
+          onClick={handleLogin}
+          disabled={isLoading}
+          className="flex w-full items-center justify-center gap-3 rounded-lg bg-gray-900 px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
+        >
+          <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+          </svg>
+          {isLoading ? "Iniciando sesión..." : "Iniciar sesión con GitHub"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/auth.ts
+++ b/frontend/auth.ts
@@ -1,0 +1,39 @@
+import NextAuth from "next-auth";
+import GitHub from "next-auth/providers/github";
+
+declare module "next-auth" {
+  interface Session {
+    githubAccessToken?: string;
+    user: {
+      id?: string;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+    };
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    githubAccessToken?: string;
+  }
+}
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  providers: [GitHub],
+  callbacks: {
+    jwt({ token, account }) {
+      if (account?.access_token) {
+        token.githubAccessToken = account.access_token;
+      }
+      return token;
+    },
+    session({ session, token }) {
+      session.githubAccessToken = token.githubAccessToken;
+      return session;
+    },
+  },
+  pages: {
+    signIn: "/login",
+  },
+});

--- a/frontend/auth.ts
+++ b/frontend/auth.ts
@@ -13,7 +13,7 @@ declare module "next-auth" {
   }
 }
 
-declare module "next-auth/jwt" {
+declare module "@auth/core/jwt" {
   interface JWT {
     githubAccessToken?: string;
   }

--- a/frontend/components/app-shell.tsx
+++ b/frontend/components/app-shell.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Sidebar } from "@/components/sidebar";
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isLoginPage = pathname === "/login";
+
+  if (isLoginPage) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar />
+      <main className="flex-1 overflow-auto">{children}</main>
+    </div>
+  );
+}

--- a/frontend/components/auth-provider.tsx
+++ b/frontend/components/auth-provider.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { SessionProvider, useSession } from "next-auth/react";
+import { useEffect, useRef } from "react";
+import { loginToBackend } from "@/lib/api";
+import { useExtractionStore } from "@/lib/store";
+
+function BackendAuthSync({ children }: { children: React.ReactNode }) {
+  const { data: session, status } = useSession();
+  const { backendToken, setBackendAuth, clearBackendAuth } = useExtractionStore();
+  const loginAttempted = useRef(false);
+
+  useEffect(() => {
+    if (status !== "authenticated" || !session?.githubAccessToken) return;
+    if (backendToken || loginAttempted.current) return;
+
+    loginAttempted.current = true;
+
+    loginToBackend(session.githubAccessToken)
+      .then((res) => {
+        setBackendAuth(res.access_token, res.user);
+      })
+      .catch((err) => {
+        console.error("Backend login failed:", err);
+        clearBackendAuth();
+      });
+  }, [status, session, backendToken, setBackendAuth, clearBackendAuth]);
+
+  // Reset loginAttempted when session changes (e.g., re-login)
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      loginAttempted.current = false;
+      clearBackendAuth();
+    }
+  }, [status, clearBackendAuth]);
+
+  return <>{children}</>;
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <SessionProvider>
+      <BackendAuthSync>{children}</BackendAuthSync>
+    </SessionProvider>
+  );
+}

--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -2,8 +2,10 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { FileUp, BarChart3, Settings } from "lucide-react";
+import { signOut } from "next-auth/react";
+import { FileUp, BarChart3, Settings, Users, LogOut } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useExtractionStore } from "@/lib/store";
 
 const navigation = [
   { name: "Extraer PDF", href: "/", icon: FileUp },
@@ -11,8 +13,24 @@ const navigation = [
   { name: "Dashboard", href: "/dashboard", icon: BarChart3 },
 ];
 
+const adminNavigation = [
+  { name: "Usuarios", href: "/admin/users", icon: Users },
+];
+
 export function Sidebar() {
   const pathname = usePathname();
+  const backendUser = useExtractionStore((s) => s.backendUser);
+  const clearBackendAuth = useExtractionStore((s) => s.clearBackendAuth);
+  const isAdmin = backendUser?.role === "admin";
+
+  const handleSignOut = () => {
+    clearBackendAuth();
+    signOut({ callbackUrl: "/login" });
+  };
+
+  const allNavigation = isAdmin
+    ? [...navigation, ...adminNavigation]
+    : navigation;
 
   return (
     <div className="flex h-screen w-64 flex-col bg-gray-900 text-white">
@@ -20,7 +38,7 @@ export function Sidebar() {
         <h1 className="text-xl font-bold">Bank Extraction</h1>
       </div>
       <nav className="flex-1 space-y-1 px-3 py-4">
-        {navigation.map((item) => {
+        {allNavigation.map((item) => {
           const Icon = item.icon;
           const isActive =
             item.href === "/"
@@ -44,7 +62,39 @@ export function Sidebar() {
         })}
       </nav>
       <div className="border-t border-gray-800 p-4">
-        <p className="text-xs text-gray-400">Capstone Project v1.0</p>
+        {backendUser ? (
+          <div className="space-y-3">
+            <div className="flex items-center gap-3">
+              {backendUser.avatar_url && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={backendUser.avatar_url}
+                  alt={backendUser.github_username}
+                  className="h-8 w-8 rounded-full"
+                />
+              )}
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-white">
+                  {backendUser.github_username}
+                </p>
+                {isAdmin && (
+                  <span className="inline-flex rounded bg-yellow-500/20 px-1.5 py-0.5 text-xs font-medium text-yellow-300">
+                    Admin
+                  </span>
+                )}
+              </div>
+            </div>
+            <button
+              onClick={handleSignOut}
+              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-300 transition-colors hover:bg-gray-800 hover:text-white"
+            >
+              <LogOut className="h-4 w-4" />
+              Cerrar sesión
+            </button>
+          </div>
+        ) : (
+          <p className="text-xs text-gray-400">Capstone Project v1.0</p>
+        )}
       </div>
     </div>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,34 @@
+import { useExtractionStore } from "./store";
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+function getAuthHeaders(): Record<string, string> {
+  const token = useExtractionStore.getState().backendToken;
+  if (token) {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return {};
+}
+
+async function authFetch(url: string, init?: RequestInit): Promise<Response> {
+  const authHeaders = getAuthHeaders();
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      ...authHeaders,
+      ...init?.headers,
+    },
+  });
+
+  if (response.status === 401) {
+    useExtractionStore.getState().clearBackendAuth();
+    if (typeof window !== "undefined") {
+      window.location.href = "/login";
+    }
+  }
+
+  return response;
+}
 
 async function parseErrorDetail(response: Response, fallback: string): Promise<string> {
   try {
@@ -104,6 +134,83 @@ export interface ModelInfo {
   is_available: boolean;
 }
 
+// Auth
+export interface BackendUser {
+  id: number;
+  github_username: string;
+  email: string | null;
+  avatar_url: string | null;
+  role: string;
+}
+
+export interface LoginResponse {
+  access_token: string;
+  token_type: string;
+  user: BackendUser;
+}
+
+export async function loginToBackend(githubAccessToken: string): Promise<LoginResponse> {
+  const response = await fetch(`${API_BASE_URL}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ github_access_token: githubAccessToken }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await parseErrorDetail(response, "Login failed"));
+  }
+
+  return response.json();
+}
+
+export async function getMe(): Promise<BackendUser> {
+  const response = await authFetch(`${API_BASE_URL}/auth/me`);
+  if (!response.ok) throw new Error("Failed to fetch user info");
+  return response.json();
+}
+
+// Admin
+export interface AdminUser {
+  id: number;
+  github_id: number | null;
+  github_username: string;
+  email: string | null;
+  avatar_url: string | null;
+  role: string;
+  is_active: boolean;
+}
+
+export async function getUsers(): Promise<AdminUser[]> {
+  const response = await authFetch(`${API_BASE_URL}/admin/users`);
+  if (!response.ok) throw new Error(await parseErrorDetail(response, "Failed to fetch users"));
+  return response.json();
+}
+
+export async function createUser(github_username: string, role: string = "user"): Promise<AdminUser> {
+  const response = await authFetch(`${API_BASE_URL}/admin/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ github_username, role }),
+  });
+  if (!response.ok) throw new Error(await parseErrorDetail(response, "Failed to create user"));
+  return response.json();
+}
+
+export async function updateUser(id: number, data: { role?: string; is_active?: boolean }): Promise<AdminUser> {
+  const response = await authFetch(`${API_BASE_URL}/admin/users/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) throw new Error(await parseErrorDetail(response, "Failed to update user"));
+  return response.json();
+}
+
+export async function deleteUser(id: number): Promise<void> {
+  const response = await authFetch(`${API_BASE_URL}/admin/users/${id}`, { method: "DELETE" });
+  if (!response.ok) throw new Error(await parseErrorDetail(response, "Failed to delete user"));
+}
+
 // Upload
 export interface UploadResult {
   s3_key: string;
@@ -112,7 +219,7 @@ export interface UploadResult {
 
 export async function uploadFile(file: File): Promise<UploadResult> {
   // Step 1: Request a presigned upload URL
-  const urlResponse = await fetch(`${API_BASE_URL}/extraction/upload-url`, {
+  const urlResponse = await authFetch(`${API_BASE_URL}/extraction/upload-url`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ filename: file.name, content_type: file.type || "application/pdf" }),
@@ -149,7 +256,7 @@ export async function uploadFile(file: File): Promise<UploadResult> {
     const formData = new FormData();
     formData.append("file", file);
 
-    const fallbackResponse = await fetch(`${API_BASE_URL}/extraction/upload`, {
+    const fallbackResponse = await authFetch(`${API_BASE_URL}/extraction/upload`, {
       method: "POST",
       body: formData,
     });
@@ -164,7 +271,7 @@ export async function uploadFile(file: File): Promise<UploadResult> {
 
 // Extraction
 export async function extractFromFile(s3Key: string, filename: string, extractorConfigId?: number | null): Promise<ExtractionResult> {
-  const response = await fetch(`${API_BASE_URL}/extraction/extract`, {
+  const response = await authFetch(`${API_BASE_URL}/extraction/extract`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -182,7 +289,7 @@ export async function extractFromFile(s3Key: string, filename: string, extractor
 }
 
 export async function submitExtraction(payload: SubmissionPayload): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/extraction/submit`, {
+  const response = await authFetch(`${API_BASE_URL}/extraction/submit`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
@@ -194,7 +301,7 @@ export async function submitExtraction(payload: SubmissionPayload): Promise<void
 }
 
 export async function getBanks(): Promise<Bank[]> {
-  const response = await fetch(`${API_BASE_URL}/extraction/banks`);
+  const response = await authFetch(`${API_BASE_URL}/extraction/banks`);
   if (!response.ok) throw new Error("Failed to fetch banks");
   const data = await response.json();
   return data.banks;
@@ -203,21 +310,21 @@ export async function getBanks(): Promise<Bank[]> {
 export async function getExtractionLogs(page: number = 1, pageSize: number = 50, extractorConfigId?: number | null): Promise<PaginatedLogsResponse> {
   const params = new URLSearchParams({ page: String(page), page_size: String(pageSize) });
   if (extractorConfigId != null) params.set("extractor_config_id", String(extractorConfigId));
-  const response = await fetch(`${API_BASE_URL}/extraction/logs?${params}`);
+  const response = await authFetch(`${API_BASE_URL}/extraction/logs?${params}`);
   if (!response.ok) throw new Error("Failed to fetch extraction logs");
   return response.json();
 }
 
 export async function getApiCallMetrics(extractorConfigId?: number | null): Promise<ApiCallMetrics> {
   const params = extractorConfigId != null ? `?extractor_config_id=${extractorConfigId}` : "";
-  const response = await fetch(`${API_BASE_URL}/extraction/api-metrics${params}`);
+  const response = await authFetch(`${API_BASE_URL}/extraction/api-metrics${params}`);
   if (!response.ok) throw new Error("Failed to fetch API call metrics");
   return response.json();
 }
 
 export async function getMetrics(extractorConfigId?: number | null): Promise<Metrics> {
   const params = extractorConfigId != null ? `?extractor_config_id=${extractorConfigId}` : "";
-  const response = await fetch(`${API_BASE_URL}/extraction/metrics${params}`);
+  const response = await authFetch(`${API_BASE_URL}/extraction/metrics${params}`);
   if (!response.ok) throw new Error("Failed to fetch metrics");
   return response.json();
 }
@@ -225,14 +332,14 @@ export async function getMetrics(extractorConfigId?: number | null): Promise<Met
 // Extractor Configs
 export async function getExtractorConfigs(status?: string): Promise<ExtractorConfig[]> {
   const params = status != null ? `?status=${status}` : "";
-  const response = await fetch(`${API_BASE_URL}/extractors${params}`);
+  const response = await authFetch(`${API_BASE_URL}/extractors${params}`);
   if (!response.ok) throw new Error("Failed to fetch extractor configs");
   const data = await response.json();
   return data.configs;
 }
 
 export async function getExtractorConfig(id: number): Promise<ExtractorConfig> {
-  const response = await fetch(`${API_BASE_URL}/extractors/${id}`);
+  const response = await authFetch(`${API_BASE_URL}/extractors/${id}`);
   if (!response.ok) throw new Error("Failed to fetch extractor config");
   return response.json();
 }
@@ -246,7 +353,7 @@ export async function createExtractorConfig(config: {
   is_default?: boolean;
   status?: string;
 }): Promise<ExtractorConfig> {
-  const response = await fetch(`${API_BASE_URL}/extractors`, {
+  const response = await authFetch(`${API_BASE_URL}/extractors`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(config),
@@ -266,7 +373,7 @@ export async function updateExtractorConfig(id: number, config: {
   is_default?: boolean;
   status?: string;
 }): Promise<ExtractorConfig> {
-  const response = await fetch(`${API_BASE_URL}/extractors/${id}`, {
+  const response = await authFetch(`${API_BASE_URL}/extractors/${id}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(config),
@@ -278,20 +385,20 @@ export async function updateExtractorConfig(id: number, config: {
 }
 
 export async function deleteExtractorConfig(id: number): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/extractors/${id}`, { method: "DELETE" });
+  const response = await authFetch(`${API_BASE_URL}/extractors/${id}`, { method: "DELETE" });
   if (!response.ok) {
     throw new Error(await parseErrorDetail(response, "Failed to delete extractor config"));
   }
 }
 
 export async function getAvailableModels(): Promise<ModelInfo[]> {
-  const response = await fetch(`${API_BASE_URL}/extractors/models`);
+  const response = await authFetch(`${API_BASE_URL}/extractors/models`);
   if (!response.ok) throw new Error("Failed to fetch models");
   return response.json();
 }
 
 export async function getExtractorVersions(id: number): Promise<ExtractorConfigVersion[]> {
-  const response = await fetch(`${API_BASE_URL}/extractors/${id}/versions`);
+  const response = await authFetch(`${API_BASE_URL}/extractors/${id}/versions`);
   if (!response.ok) throw new Error("Failed to fetch versions");
   return response.json();
 }
@@ -302,7 +409,7 @@ export async function testExtract(
   config: { prompt: string; model: string; output_schema: Record<string, unknown> },
   extractorConfigId?: number | null
 ): Promise<{ fields: Record<string, unknown>; response_time_ms: number; test_log_id: number | null }> {
-  const response = await fetch(`${API_BASE_URL}/extractors/test-extract`, {
+  const response = await authFetch(`${API_BASE_URL}/extractors/test-extract`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -321,7 +428,7 @@ export async function testExtract(
 }
 
 export async function generateSchema(description: string): Promise<{ output_schema: Record<string, unknown> }> {
-  const response = await fetch(`${API_BASE_URL}/extractors/generate-schema`, {
+  const response = await authFetch(`${API_BASE_URL}/extractors/generate-schema`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ description }),
@@ -336,7 +443,7 @@ export async function generatePrompt(
   output_schema: Record<string, unknown>,
   document_type: string | null
 ): Promise<{ prompt: string }> {
-  const response = await fetch(`${API_BASE_URL}/extractors/generate-prompt`, {
+  const response = await authFetch(`${API_BASE_URL}/extractors/generate-prompt`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ output_schema, document_type }),
@@ -352,7 +459,7 @@ export async function updatePrompt(
   instructions: string,
   output_schema: Record<string, unknown>
 ): Promise<{ prompt: string }> {
-  const response = await fetch(`${API_BASE_URL}/extractors/update-prompt`, {
+  const response = await authFetch(`${API_BASE_URL}/extractors/update-prompt`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ current_prompt, instructions, output_schema }),
@@ -368,7 +475,7 @@ export async function toggleVersionActive(
   versionId: number,
   isActive: boolean
 ): Promise<ExtractorConfigVersion> {
-  const response = await fetch(
+  const response = await authFetch(
     `${API_BASE_URL}/extractors/${configId}/versions/${versionId}/active`,
     {
       method: "PATCH",

--- a/frontend/lib/hooks.ts
+++ b/frontend/lib/hooks.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useExtractionStore } from "@/lib/store";
 import {
   getBanks,
   getExtractorConfigs,
@@ -19,6 +20,10 @@ import {
   generatePrompt,
   updatePrompt,
   getAvailableModels,
+  getUsers,
+  createUser,
+  updateUser,
+  deleteUser,
   SubmissionPayload,
 } from "@/lib/api";
 
@@ -33,63 +38,83 @@ export const queryKeys = {
   extractionLogs: (page: number, pageSize: number, configId?: number | null) =>
     ["extractionLogs", page, pageSize, configId] as const,
   availableModels: ["availableModels"] as const,
+  users: ["users"] as const,
 };
+
+function useIsAuthenticated() {
+  return !!useExtractionStore((s) => s.backendToken);
+}
 
 // Queries
 export function useBanks() {
+  const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.banks,
     queryFn: getBanks,
+    enabled: authed,
   });
 }
 
 export function useExtractorConfigs(status?: string) {
+  const authed = useIsAuthenticated();
   return useQuery({
     queryKey: [...queryKeys.extractorConfigs, status],
     queryFn: () => getExtractorConfigs(status),
+    enabled: authed,
   });
 }
 
 export function useExtractorConfig(id: number, options?: { enabled?: boolean }) {
+  const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.extractorConfig(id),
     queryFn: () => getExtractorConfig(id),
-    enabled: options?.enabled,
+    enabled: authed && (options?.enabled ?? true),
   });
 }
 
 export function useExtractorVersions(configId: number) {
+  const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.extractorVersions(configId),
     queryFn: () => getExtractorVersions(configId),
+    enabled: authed,
   });
 }
 
 export function useMetrics(configId?: number | null) {
+  const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.metrics(configId),
     queryFn: () => getMetrics(configId),
+    enabled: authed,
   });
 }
 
 export function useApiCallMetrics(configId?: number | null) {
+  const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.apiCallMetrics(configId),
     queryFn: () => getApiCallMetrics(configId),
+    enabled: authed,
   });
 }
 
 export function useExtractionLogs(page: number, pageSize: number, configId?: number | null) {
+  const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.extractionLogs(page, pageSize, configId),
     queryFn: () => getExtractionLogs(page, pageSize, configId),
+    enabled: authed,
   });
 }
 
 export function useAvailableModels() {
+  const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.availableModels,
     queryFn: getAvailableModels,
+    enabled: authed,
   });
 }
 
@@ -239,5 +264,47 @@ export function useUpdatePrompt() {
       instructions: string;
       output_schema: Record<string, unknown>;
     }) => updatePrompt(current_prompt, instructions, output_schema),
+  });
+}
+
+// Admin hooks
+export function useUsers() {
+  const authed = useIsAuthenticated();
+  return useQuery({
+    queryKey: queryKeys.users,
+    queryFn: getUsers,
+    enabled: authed,
+  });
+}
+
+export function useCreateUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ github_username, role }: { github_username: string; role: string }) =>
+      createUser(github_username, role),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.users });
+    },
+  });
+}
+
+export function useUpdateUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: { role?: string; is_active?: boolean } }) =>
+      updateUser(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.users });
+    },
+  });
+}
+
+export function useDeleteUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => deleteUser(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.users });
+    },
   });
 }

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -2,6 +2,14 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { ExtractionResult } from "./api";
 
+interface AuthUser {
+  id: number;
+  github_username: string;
+  email: string | null;
+  avatar_url: string | null;
+  role: string;
+}
+
 interface ExtractionState {
   file: File | null;
   fileName: string | null;
@@ -9,11 +17,15 @@ interface ExtractionState {
   extracted: ExtractionResult | null;
   formData: Record<string, string>;
   selectedExtractorId: number | null;
+  backendToken: string | null;
+  backendUser: AuthUser | null;
   setFile: (file: File | null) => void;
   setExtracted: (extracted: ExtractionResult | null) => void;
   setFormData: (formData: Record<string, string>) => void;
   updateFormField: (field: string, value: string) => void;
   setSelectedExtractorId: (id: number | null) => void;
+  setBackendAuth: (token: string, user: AuthUser) => void;
+  clearBackendAuth: () => void;
   reset: () => void;
 }
 
@@ -24,6 +36,8 @@ const initialState = {
   extracted: null,
   formData: {} as Record<string, string>,
   selectedExtractorId: null as number | null,
+  backendToken: null as string | null,
+  backendUser: null as AuthUser | null,
 };
 
 export const useExtractionStore = create<ExtractionState>()(
@@ -62,6 +76,10 @@ export const useExtractionStore = create<ExtractionState>()(
 
       setSelectedExtractorId: (id) => set({ selectedExtractorId: id }),
 
+      setBackendAuth: (token, user) => set({ backendToken: token, backendUser: user }),
+
+      clearBackendAuth: () => set({ backendToken: null, backendUser: null }),
+
       reset: () => set(initialState),
     }),
     {
@@ -72,6 +90,8 @@ export const useExtractionStore = create<ExtractionState>()(
         extracted: state.extracted,
         formData: state.formData,
         selectedExtractorId: state.selectedExtractorId,
+        backendToken: state.backendToken,
+        backendUser: state.backendUser,
       }),
     }
   )

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,22 @@
+import { auth } from "@/auth";
+import { NextResponse } from "next/server";
+
+export default auth((req) => {
+  if (!req.auth) {
+    const loginUrl = new URL("/login", req.url);
+    return NextResponse.redirect(loginUrl);
+  }
+  return NextResponse.next();
+});
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except:
+     * - /login
+     * - /api/auth/* (NextAuth routes)
+     * - _next/static, _next/image, favicon.ico, public assets
+     */
+    "/((?!login|api/auth|_next/static|_next/image|favicon\\.ico).*)",
+  ],
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "cmdk": "^1.0.0",
         "lucide-react": "^0.446.0",
         "next": "^15.5.12",
+        "next-auth": "^5.0.0-beta.30",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-zoom-pan-pinch": "^3.7.0",
@@ -51,6 +52,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
+      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -980,6 +1010,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -5502,6 +5541,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5865,6 +5913,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
+      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.0"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -5918,6 +5993,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -6416,6 +6500,25 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "cmdk": "^1.0.0",
     "lucide-react": "^0.446.0",
     "next": "^15.5.12",
+    "next-auth": "^5.0.0-beta.30",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-zoom-pan-pinch": "^3.7.0",

--- a/wiki/Análisis-de-Costos.md
+++ b/wiki/Análisis-de-Costos.md
@@ -1,0 +1,141 @@
+# Análisis de Costos por Solicitud de Extracción
+
+## Stack actual
+
+| Servicio | Propósito | Costo actual |
+|----------|-----------|-------------|
+| **Claude API (Haiku 4.5)** | Extracción de documentos + AI assistant | Por uso |
+| **Railway** | Backend (FastAPI) + PostgreSQL | Gratis (free tier) |
+| **Vercel** | Frontend (Next.js) | Gratis (free tier) |
+| **Tigris (S3-compatible)** | Almacenamiento de archivos | Gratis (incluido en Railway) |
+
+> Railway y Vercel están en free tier por ahora. Los costos de infraestructura aplican solo cuando se superen los límites gratuitos.
+
+---
+
+## 1. Claude API — Costo principal
+
+**Modelo:** `claude-haiku-4-5-20251001`
+
+| Concepto | Precio |
+|----------|--------|
+| Input tokens | $1.00 / millón de tokens |
+| Output tokens | $5.00 / millón de tokens |
+
+### Extracción de imágenes (JPG/PNG)
+
+Se realizan **2 llamadas** a Claude por imagen: verificación de orientación + extracción.
+
+| Llamada | Input tokens | Output tokens | Costo |
+|---------|-------------|---------------|-------|
+| Orientation check | ~1,650 | ~50 | ~$0.0019 |
+| Extracción | ~1,900 | ~200 | ~$0.0029 |
+| **Total por imagen** | | | **~$0.005** |
+
+### Extracción de PDFs
+
+Claude convierte cada página del PDF en imagen (~1,500 tokens/página). **1 sola llamada**.
+
+| Escenario | Páginas | Input tokens | Costo estimado |
+|-----------|---------|-------------|----------------|
+| PDF chico (carátula) | 1-2 | ~3,300 | **~$0.004** |
+| PDF mediano | 10 | ~15,300 | **~$0.016** |
+| PDF grande | 50 | ~75,300 | **~$0.077** |
+| PDF máximo (~20MB) | 100 | ~150,300 | **~$0.15** |
+
+> Nota: Claude soporta máximo 100 páginas por PDF.
+
+### AI Assistant (costos one-time por extractor)
+
+Estas llamadas ocurren solo al **crear o editar** un extractor, no por cada extracción.
+
+| Operación | Input tokens | Output tokens | Costo estimado |
+|-----------|-------------|---------------|----------------|
+| Generar schema | ~500 | ~500 | ~$0.003 |
+| Generar prompt | ~600 | ~500 | ~$0.003 |
+| Refinar prompt | ~800 | ~500 | ~$0.004 |
+
+---
+
+## 2. S3 Storage (Tigris)
+
+Actualmente incluido en Railway free tier. Costos futuros de referencia:
+
+| Concepto | Costo |
+|----------|-------|
+| PUT (upload) | ~$0.000005/request |
+| GET (download) | ~$0.0000004/request |
+| Almacenamiento | ~$0.023/GB/mes |
+| **Total por request** | **< $0.001 (despreciable)** |
+
+Un archivo de 20MB almacenado cuesta ~$0.0005/mes.
+
+---
+
+## 3. Infraestructura (post free-tier)
+
+Estos costos aplican solo cuando se excedan los free tiers.
+
+| Servicio | Costo mensual estimado | A 1,000 req/mes | A 10,000 req/mes |
+|----------|----------------------|-----------------|------------------|
+| Railway (backend + DB) | ~$5-20/mes | ~$0.02/req | ~$0.002/req |
+| Vercel (frontend) | ~$0-20/mes | ~$0.02/req | ~$0.002/req |
+| **Total infra** | **~$10-40/mes** | **~$0.04/req** | **~$0.004/req** |
+
+---
+
+## Resumen: Costo total por solicitud
+
+### Fase actual (free tiers activos)
+
+Solo se paga Claude API:
+
+| Escenario | Costo por solicitud |
+|-----------|-------------------|
+| Imagen simple | **~$0.005** |
+| PDF 1-2 páginas | **~$0.004** |
+| PDF 10 páginas | **~$0.016** |
+| PDF 50 páginas | **~$0.077** |
+| PDF 100 páginas (~20MB) | **~$0.15** |
+
+### Fase futura (sin free tiers, ~1,000 req/mes)
+
+| Escenario | Claude API | Infra | **Total** |
+|-----------|-----------|-------|-----------|
+| Imagen simple | $0.005 | $0.04 | **~$0.045** |
+| PDF 1-2 páginas | $0.004 | $0.04 | **~$0.044** |
+| PDF 10 páginas | $0.016 | $0.04 | **~$0.056** |
+| PDF 50 páginas | $0.077 | $0.04 | **~$0.117** |
+| PDF 100 páginas (~20MB) | $0.15 | $0.04 | **~$0.19** |
+
+---
+
+## Precio sugerido por solicitud
+
+Margen recomendado: **3x-5x** sobre costo total (fase futura).
+
+| Escenario | Costo | Precio 3x | Precio 5x |
+|-----------|-------|-----------|-----------|
+| Documento típico (1-10 págs) | ~$0.05 | **$0.15** | **$0.25** |
+| Documento grande (50+ págs) | ~$0.12 | **$0.36** | **$0.60** |
+| Worst case (100 págs, 20MB) | ~$0.19 | **$0.57** | **$0.95** |
+
+### Modelos de pricing sugeridos
+
+1. **Precio flat:** $0.15 - $0.25 USD por extracción (cubre ~80% de casos con buen margen)
+2. **Por tiers:**
+   - Documentos ≤20 páginas: $0.15
+   - Documentos >20 páginas: $0.50
+3. **Paquetes de créditos:**
+   - 100 extracciones: $15-20 USD
+   - 500 extracciones: $60-80 USD
+   - 1,000 extracciones: $100-150 USD
+
+---
+
+## Consideraciones
+
+- **Cambio de modelo:** Migrar a Sonnet multiplica el costo de API ~3x. Migrar a Opus ~15x.
+- **Orientation check:** Solo aplica a imágenes, no a PDFs. Se podría eliminar si los documentos siempre llegan bien orientados.
+- **Archivos de 20MB:** El límite práctico es 100 páginas (límite de Claude), no el tamaño del archivo.
+- **Volumen:** A mayor volumen, el costo de infra por request baja drásticamente. El costo de API se mantiene lineal.

--- a/wiki/Arquitectura-Mínima-Operable.md
+++ b/wiki/Arquitectura-Mínima-Operable.md
@@ -29,10 +29,14 @@
 ```
 ┌─────────────────────────────────────────┐
 │          Cliente (Web UI)               │
+│  - NextAuth.js (GitHub OAuth)           │
+│  - Middleware de protección de rutas    │
 └─────────────────────────────────────────┘
                    ↓
 ┌─────────────────────────────────────────┐
 │         API REST (FastAPI)              │
+│  - POST /auth/login (GitHub → JWT)      │
+│  - GET /admin/users (gestión)           │
 │  - POST /extraction/upload-url          │
 │  - POST /extraction/upload (fallback)   │
 │  - POST /extraction/extract             │
@@ -52,9 +56,10 @@
 │Postgre │  │  S3 /    │  │ Claude       │
 │  SQL   │  │  Tigris  │  │ Haiku 4.5    │
 │        │  │          │  │              │
-│-Logs   │  │ -PDFs    │  │ -Vision API  │
-│-API    │  │ -Images  │  │ -Structured  │
-│ Calls  │  │          │  │  Output      │
+│-Users  │  │ -PDFs    │  │ -Vision API  │
+│-Logs   │  │ -Images  │  │ -Structured  │
+│-API    │  │          │  │  Output      │
+│ Calls  │  │          │  │              │
 └────────┘  └──────────┘  └──────────────┘
 ```
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -67,11 +67,14 @@ capstone-project/
 │   │   │   ├── entities.py         # Entidades de dominio y API calls
 │   │   │   └── services/           # Servicios de negocio
 │   │   ├── infrastructure/         # Integraciones externas
+│   │   │   ├── api/auth/           # Rutas de autenticación (/auth)
+│   │   │   ├── api/admin/          # Rutas de administración (/admin/users)
 │   │   │   ├── api/extraction/     # Rutas HTTP y DTOs (/extraction)
 │   │   │   ├── api/extractors/     # Rutas HTTP (/extractors CRUD, AI, test)
+│   │   │   ├── auth.py             # JWT y validación de tokens GitHub
 │   │   │   ├── ai_assist.py        # Generacion de schemas/prompts con Claude
 │   │   │   ├── database.py         # Configuracion PostgreSQL
-│   │   │   ├── models.py           # ORM (ExtractionLog, ApiCallLog, TestExtractionLog)
+│   │   │   ├── models.py           # ORM (User, ExtractionLog, ApiCallLog, etc.)
 │   │   │   ├── repository.py       # Acceso a datos
 │   │   │   ├── storage.py          # StorageBackend (S3 / local)
 │   │   │   ├── extractors/        # StatementExtractor (vision unificado)
@@ -86,11 +89,16 @@ capstone-project/
 │
 └── frontend/                       # Aplicacion Next.js
     ├── app/                        # Pages (Next.js 15 App Router)
+    │   ├── login/                  # Página de login (GitHub OAuth)
     │   ├── page.tsx                # Extraccion
     │   ├── extractors/             # Gestion de extractores (CRUD + wizard)
     │   ├── dashboard/              # Dashboard
+    │   ├── admin/users/            # Gestion de usuarios (admin)
     │   └── layout.tsx              # Layout con sidebar
+    ├── auth.ts                     # Configuración NextAuth.js (GitHub OAuth)
+    ├── middleware.ts               # Protección de rutas
     ├── components/                 # Componentes React + shadcn/ui
+    │   ├── auth-provider.tsx       # Proveedor de autenticación
     │   ├── assistant/              # Sidebar de asistente IA
     │   ├── extractor-wizard/       # Wizard multi-paso para extractores
     │   ├── schema-builder/         # Editor visual de schemas JSON
@@ -128,6 +136,9 @@ capstone-project/
 
 ### Completamente Implementado
 
+- Autenticacion con *GitHub OAuth* (*NextAuth.js*) y tokens *JWT* en el *backend*
+- *Multi-tenancy* con tabla de usuarios, roles (*user*/*admin*) y datos aislados por usuario
+- Panel de administracion para gestion de usuarios (crear, editar rol, activar/desactivar, eliminar)
 - Extractores configurables con *schemas*, *prompts* y modelos personalizados
 - *Wizard* multi-paso para crear extractores con asistente de IA
 - Generacion de *schemas* y *prompts* asistida por Claude (`ai_assist.py`)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -17,6 +17,9 @@
 - [Comparación de *Parsers*](Comparación-de-Parsers)
 - [*Workflow* Semanal](Workflow-Semanal)
 
+### Operación
+- [Análisis de Costos](Análisis-de-Costos)
+
 ### *Frontend*
 - [Configuración](Configuración-Frontend)
 - [Resumen de Implementación](Resumen-Implementación)

--- a/wiki/Últimas-Actualizaciones.md
+++ b/wiki/Últimas-Actualizaciones.md
@@ -2,6 +2,20 @@
 
 **Ultima actualizacion:** Marzo 2026
 
+## Actualizacion: Autenticacion y *Multi-tenancy* (Marzo 2026)
+
+### Cambios principales
+
+- **Autenticacion con *GitHub OAuth***: Login via *NextAuth.js* con proveedor de *GitHub*. El *frontend* intercambia el *access token* de *GitHub* por un *JWT* del *backend* (`POST /auth/login`). Middleware protege todas las rutas excepto `/login`
+- ***Multi-tenancy***: Nueva tabla `users` con roles (`user`/`admin`). Todas las tablas existentes (`extractor_configs`, `extraction_logs`, `api_call_logs`, `test_extraction_logs`) tienen `user_id` *FK*. Extractores con restriccion de nombre unico por usuario
+- **Panel de administracion**: Nueva pagina `/admin/users` (solo admins) para gestionar usuarios: crear por *username* de *GitHub*, cambiar rol, activar/desactivar, eliminar
+- **Autenticacion en *backend***: Nuevo modulo `auth.py` con creacion/validacion de *JWT*, dependencias `get_current_user` y `get_admin_user`. Rutas protegidas reciben `user_id` del token
+- **Sidebar con usuario**: Muestra avatar y nombre del usuario autenticado, badge de admin, boton de cerrar sesion. Navegacion de admin condicional
+- **Nuevas variables de entorno**: `JWT_SECRET` (*backend*), `AUTH_GITHUB_ID`, `AUTH_GITHUB_SECRET`, `AUTH_SECRET` (*frontend*)
+- **Migracion Alembic**: Tabla `users`, columna `user_id` en tablas existentes, *backfill* de datos existentes al usuario admin
+
+---
+
 ## Actualizacion: Extractores Configurables, Asistente IA y *React Query* (Marzo 2026)
 
 ### Cambios principales
@@ -54,8 +68,9 @@ El proyecto esta completamente funcional con todas las funcionalidades principal
 
 ### 1. Navegacion con *Sidebar*
 - *Sidebar* oscuro con navegación implementado
-- Dos páginas funcionales: "Extraer PDF" y "*Dashboard*"
+- Páginas: "Extraer PDF", "Extractores", "*Dashboard*", y "Usuarios" (admin)
 - Resaltado de estado activo
+- Perfil de usuario con avatar, badge de admin y cierre de sesion
 - Diseño profesional con *sidebar* fijo
 
 ### 2. *Dropdown* de Selección de Banco
@@ -149,6 +164,12 @@ POST /extractors/update-prompt    - Refinar prompt con IA
 POST /extractors/test-extract     - Probar extraccion con registro
 GET  /extractors/models           - Listar modelos disponibles
 GET  /extractors/versions         - Versiones de un extractor
+POST /auth/login                 - Login con token de GitHub, retorna JWT
+GET  /auth/me                    - Obtener usuario autenticado
+GET  /admin/users                - Listar usuarios (admin)
+POST /admin/users                - Crear usuario (admin)
+PUT  /admin/users/{id}           - Actualizar usuario (admin)
+DELETE /admin/users/{id}         - Eliminar usuario (admin)
 GET  /health                    - Verificacion de salud
 GET  /docs                      - Documentacion interactiva
 ```
@@ -182,7 +203,8 @@ La aplicación inicia en http://localhost:3000
 ## Base de Datos
 
 *PostgreSQL* con tablas principales:
-- `extractor_configs`: Configuraciones de extractores (*schema*, *prompt*, modelo, estado)
+- `users`: Usuarios registrados (*GitHub* ID, *username*, rol, estado)
+- `extractor_configs`: Configuraciones de extractores (*schema*, *prompt*, modelo, estado, `user_id`)
 - `extractor_config_versions`: Versiones de configuraciones para pruebas A/B
 - `extraction_logs`: Valores extraidos, correcciones del usuario, *flags* de correccion por campo
 - `api_call_logs`: Modelo utilizado, exito/error, tiempo de respuesta, tipo de error


### PR DESCRIPTION
## Summary

- **GitHub OAuth authentication** via NextAuth.js (frontend) with JWT-based backend API auth
- **Multi-tenancy**: `users` table with role-based access control (`user`/`admin`). All data tables scoped by `user_id`. Extractor configs are per-user with ownership checks on all CRUD routes
- **Admin panel** (`/admin/users`): pre-register users by GitHub username, manage roles, activate/deactivate
- **Protected routes**: middleware redirects unauthenticated users to `/login`; backend enforces auth on all endpoints

### Security fixes included
- Ownership checks on all extractor config operations (GET, PUT, DELETE, versions, test-logs, toggle-active) — prevents users from accessing other users' configs
- `user_id` propagated to `TestExtractionLog` entries
- Network error handling for GitHub token validation (returns 502 instead of unhandled 500)
- Inline `HTTPException` imports moved to module level in auth routes

### Backend changes
- New `User` model + Alembic migration adding `users` table and `user_id` FKs
- JWT auth middleware (`get_current_user`, `get_admin_user` dependencies)
- Auth routes (`/auth/login`, `/auth/me`)
- Admin routes (`/admin/users` CRUD)
- All services/repositories updated for user context

### Frontend changes
- NextAuth.js config with GitHub provider
- `BackendAuthSync` component exchanges GitHub token for backend JWT
- Login page, middleware, app shell, sidebar with user info
- Admin user management page
- API layer sends JWT `Authorization` header
- Zustand store extended with auth state

https://github.com/mateonoel2/capstone-project/issues/12

## Test plan
- [x] Login with GitHub OAuth, verify redirect and session
- [x] Verify non-admin users can only see/edit their own extractor configs
- [x] Verify admin users can see all configs and manage users
- [x] Test extraction flow end-to-end with authenticated user
- [x] Verify unauthenticated requests return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)