### PR TITLE
Add client API documentation page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ npm run lint                             # eslint
 
 Three layers under `src/`:
 
-- **`src/main.py`** — FastAPI app entry point with CORS and lifespan
+- **`src/main.py`** — FastAPI app entry point with CORS, lifespan, and client API docs (`/api/docs` with filtered OpenAPI spec)
 
 - **`src/domain/`** — Pure business logic (no external dependencies)
   - `schemas.py` — `BankAccount`, `ExtractionOutput` Pydantic models
@@ -54,11 +54,12 @@ Three layers under `src/`:
   - `api/extraction/routes.py` — HTTP routes under `/extraction`
   - `api/extraction/dtos.py` — Request/response Pydantic models
   - `api/extractors/routes.py` — HTTP routes under `/extractors` (CRUD, versioning, AI generation, test extraction)
-  - `auth.py` — JWT token creation/validation, `get_current_user`/`get_admin_user` dependencies, GitHub token validation
+  - `api/tokens/routes.py` — API token management routes (`/tokens` CRUD)
+  - `auth.py` — JWT token creation/validation, API token authentication, `get_current_user`/`get_admin_user` dependencies
   - `ai_assist.py` — Claude-powered schema generation, prompt generation, and prompt refinement
   - `database.py` — SQLAlchemy engine + session (PostgreSQL via `DATABASE_URL`)
-  - `models.py` — `User`, `ExtractorConfig`, `ExtractorConfigVersion`, `ExtractionLog`, `ApiCallLog`, `TestExtractionLog` ORM models
-  - `repository.py` — `UserRepository`, `ExtractionRepository`, `ExtractorConfigRepository`, `ApiCallRepository`, `TestExtractionLogRepository`
+  - `models.py` — `User`, `ExtractorConfig`, `ExtractorConfigVersion`, `ExtractionLog`, `ApiCallLog`, `TestExtractionLog`, `ApiToken` ORM models
+  - `repository.py` — `UserRepository`, `ExtractionRepository`, `ExtractorConfigRepository`, `ApiCallRepository`, `TestExtractionLogRepository`, `ApiTokenRepository`
   - `storage.py` — `StorageBackend` ABC with `LocalStorage` and `S3Storage` (presigned upload URLs, download, CORS config)
   - `extractors/` — `StatementExtractor`: unified vision-based extractor (PDF + images)
   - `preprocessing/` — `OCRProcessor`, `DataCleaner`, `FileValidator`, `FileDownloader`
@@ -72,12 +73,13 @@ Three layers under `src/`:
 Next.js 15 App Router with TypeScript, Tailwind CSS, Radix UI (shadcn/ui), React Query for server state, and Zustand for UI state.
 
 - `/login` — GitHub OAuth login page
-- `/` — Main extraction workflow: upload file (PDF/JPG/PNG) → preview → editable extracted fields → submit
+- `/` — Main extraction workflow: upload file (PDF/JPG/PNG) → preview → editable extracted fields → submit. Includes info banner linking to client API docs
 - `/extractors` — Extractor config management (list, create, edit, delete)
 - `/extractors/new` — Multi-step wizard to create extractor configs (identity, schema, prompt, test)
 - `/extractors/[id]/edit` — Edit existing extractor config
 - `/dashboard` — Accuracy metrics and extraction history
 - `/admin/users` — User management (admin only): create, edit roles, activate/deactivate, delete
+- `/settings/tokens` — API token management: create, revoke, view usage
 - `auth.ts` — NextAuth.js configuration (GitHub provider, JWT callbacks)
 - `middleware.ts` — Route protection (redirects unauthenticated users to `/login`)
 - `components/auth-provider.tsx` — `SessionProvider` + `BackendAuthSync` (exchanges GitHub token for backend JWT)
@@ -91,7 +93,8 @@ Next.js 15 App Router with TypeScript, Tailwind CSS, Radix UI (shadcn/ui), React
 
 ## Key Domain Concepts
 
-- **Authentication**: GitHub OAuth via NextAuth.js (frontend) + JWT tokens for backend API. Frontend exchanges GitHub access token for a backend JWT via `POST /auth/login`
+- **Authentication**: GitHub OAuth via NextAuth.js (frontend) + JWT tokens for backend API. Frontend exchanges GitHub access token for a backend JWT via `POST /auth/login`. Also supports API tokens for programmatic access (Bearer token auth), managed via `/tokens` endpoints
+- **Client API docs**: Filtered OpenAPI spec at `/api/docs` showing only client-facing endpoints (extraction, extractors, tokens). Full internal docs remain at `/docs`
 - **Multi-tenancy**: `users` table with roles (`user`/`admin`). All data tables have `user_id` FK. Extractor configs scoped per user (unique name per user). Admin pre-registers users by GitHub username
 - **Extractor config**: User-defined extraction configuration with name, model, prompt, and JSON output schema. Supports draft/active status and versioning for A/B testing
 - **Upload flow**: Frontend requests presigned URL → direct S3 PUT (with backend fallback) → extract by S3 key

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Extracción de Datos de Documentos
 
+🔗 **[Ver aplicación en producción](https://capstone-project-sigma-one.vercel.app/)**
+
 Proyecto de *capstone* para la extracción automática de información estructurada de documentos utilizando Claude Haiku 4.5. Originalmente diseñado para estados de cuenta bancarios mexicanos, ahora soporta tipos de documentos arbitrarios con extractores configurables.
 
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Sistema de producción (*FastAPI* + *Next.js*) que extrae información estructur
 - *React Query* para gestion de estado del servidor, *Zustand* para estado de UI
 - Almacenamiento en PostgreSQL con migraciones Alembic
 - Subida de archivos a S3 con *presigned URLs* (subida directa desde el navegador, con *fallback* via *backend*)
+- Tokens API para acceso programatico con autenticacion *Bearer*
+- Documentacion de API para clientes en `/api/docs` (vista filtrada del *OpenAPI spec*)
 - Despliegue en Railway (backend) y Vercel (frontend)
 - CI con GitHub Actions (ruff format, lint, tests)
 - Docker Compose para desarrollo local (backend + PostgreSQL + LocalStack)
@@ -51,6 +53,7 @@ capstone-project/
 │   │   │   ├── api/admin/            # Rutas de administración (/admin/users)
 │   │   │   ├── api/extraction/       # Rutas HTTP y DTOs (/extraction)
 │   │   │   ├── api/extractors/       # Rutas HTTP (/extractors CRUD, AI, test)
+│   │   │   ├── api/tokens/          # Rutas HTTP (/tokens CRUD)
 │   │   │   ├── auth.py                # JWT y validación de tokens GitHub
 │   │   │   ├── ai_assist.py          # Generacion de schemas/prompts con Claude
 │   │   │   ├── database.py           # SQLAlchemy + PostgreSQL
@@ -68,7 +71,7 @@ capstone-project/
 │   └── data/                          # Datos de prueba
 │
 ├── frontend/                          # Next.js 15 (App Router)
-│   ├── app/                           # Páginas (/, /login, /extractors, /dashboard, /admin)
+│   ├── app/                           # Páginas (/, /login, /extractors, /dashboard, /admin, /settings/tokens)
 │   ├── auth.ts                        # Configuración NextAuth.js (GitHub OAuth)
 │   ├── middleware.ts                  # Protección de rutas (redirige a /login)
 │   ├── components/                    # Componentes React + shadcn/ui

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,3 +1,4 @@
+import copy
 import sys
 import time
 from contextlib import asynccontextmanager
@@ -10,7 +11,8 @@ from alembic.config import Config
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.openapi.docs import get_swagger_ui_html
+from fastapi.responses import HTMLResponse, JSONResponse
 
 from alembic import command
 from src.core.logger import get_logger
@@ -41,8 +43,8 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="Bank Statement Extraction API",
-    description="Extract bank account information from PDF statements",
+    title="Extracto API",
+    description="API de extracción de documentos",
     version="1.0.0",
     lifespan=lifespan,
 )
@@ -82,11 +84,108 @@ async def value_error_handler(request: Request, exc: ValueError):
     return JSONResponse(status_code=400, content={"detail": str(exc)})
 
 
+CLIENT_ENDPOINT_WHITELIST = {
+    ("POST", "/extraction/upload-url"),
+    ("POST", "/extraction/upload"),
+    ("POST", "/extraction/extract"),
+    ("POST", "/extraction/submit"),
+    ("GET", "/extraction/banks"),
+    ("GET", "/extractors"),
+    ("GET", "/extractors/models"),
+    ("GET", "/extractors/{config_id}"),
+    ("GET", "/extractors/{config_id}/versions"),
+    ("GET", "/tokens"),
+    ("POST", "/tokens"),
+    ("DELETE", "/tokens/{token_id}"),
+}
+
+
+def _collect_refs(obj: dict | list) -> set[str]:
+    """Recursively collect all $ref schema names from an OpenAPI structure."""
+    refs: set[str] = set()
+    if isinstance(obj, dict):
+        if "$ref" in obj:
+            ref = obj["$ref"]
+            if ref.startswith("#/components/schemas/"):
+                refs.add(ref.split("/")[-1])
+        for v in obj.values():
+            refs |= _collect_refs(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            refs |= _collect_refs(item)
+    return refs
+
+
+def get_client_openapi_schema() -> dict:
+    """Return a filtered OpenAPI spec containing only client-facing endpoints."""
+    full = app.openapi()
+    spec = copy.deepcopy(full)
+
+    spec["info"] = {
+        "title": "Extracto Client API",
+        "description": (
+            "API para integración programática con Extracto.\n\n"
+            "**Autenticación:** header `Authorization: Bearer <api_token>`.\n\n"
+            "**Métricas:** las extracciones realizadas vía API se registran en el "
+            "dashboard del usuario dueño del token, igual que las extracciones "
+            "hechas desde la interfaz web."
+        ),
+        "version": spec["info"].get("version", "1.0.0"),
+    }
+
+    filtered_paths: dict = {}
+    for path, methods in spec.get("paths", {}).items():
+        filtered_methods: dict = {}
+        for method, operation in methods.items():
+            if method.upper() == "OPTIONS":
+                continue
+            if (method.upper(), path) in CLIENT_ENDPOINT_WHITELIST:
+                filtered_methods[method] = operation
+        if filtered_methods:
+            filtered_paths[path] = filtered_methods
+    spec["paths"] = filtered_paths
+
+    # Prune unused schemas
+    used_refs = _collect_refs(filtered_paths)
+    # Resolve transitively
+    schemas = spec.get("components", {}).get("schemas", {})
+    resolved: set[str] = set()
+    queue = list(used_refs)
+    while queue:
+        name = queue.pop()
+        if name in resolved:
+            continue
+        resolved.add(name)
+        if name in schemas:
+            for dep in _collect_refs(schemas[name]):
+                if dep not in resolved:
+                    queue.append(dep)
+    spec.setdefault("components", {})["schemas"] = {
+        k: v for k, v in schemas.items() if k in resolved
+    }
+
+    return spec
+
+
+@app.get("/api/openapi.json", include_in_schema=False)
+async def client_openapi():
+    return JSONResponse(get_client_openapi_schema())
+
+
+@app.get("/api/docs", include_in_schema=False, response_class=HTMLResponse)
+async def client_docs():
+    return get_swagger_ui_html(
+        openapi_url="/api/openapi.json",
+        title="Extracto Client API",
+    )
+
+
 @app.get("/")
 async def root():
     return {
-        "message": "Bank Statement Extraction API",
+        "message": "Extracto API",
         "docs": "/docs",
+        "client_docs": "/api/docs",
         "health": "/health",
     }
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -25,7 +25,7 @@ import {
 import { toStr } from "@/lib/utils";
 import { useExtractionStore } from "@/lib/store";
 import { useBanks, useExtractorConfigs, useUploadAndExtract, useSubmitExtraction } from "@/lib/hooks";
-import { Loader2, CheckCircle, AlertCircle } from "lucide-react";
+import { Loader2, CheckCircle, AlertCircle, Info } from "lucide-react";
 import { useT } from "@/lib/i18n";
 
 export default function Home() {
@@ -141,6 +141,22 @@ export default function Home() {
           </h1>
           <p className="text-gray-600 mt-1">
             {t("extraction.subtitle")}
+          </p>
+        </div>
+
+        <div className="mb-4 flex items-start gap-2 rounded-lg bg-blue-50 border border-blue-200 px-4 py-3 text-sm text-blue-800">
+          <Info className="h-4 w-4 mt-0.5 flex-shrink-0" />
+          <p>
+            {t("extraction.apiNote")}{" "}
+            <a
+              href={`${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"}/api/docs`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium underline hover:text-blue-900"
+            >
+              {t("extraction.apiDocsLink")}
+            </a>
+            {t("extraction.apiNoteSuffix")}
           </p>
         </div>
 

--- a/frontend/lib/i18n/en.json
+++ b/frontend/lib/i18n/en.json
@@ -49,7 +49,10 @@
     "submit": "Submit",
     "reset": "Reset",
     "extractionFailed": "Extraction failed",
-    "submissionFailed": "Submission failed"
+    "submissionFailed": "Submission failed",
+    "apiNote": "To integrate extraction into your systems, see the",
+    "apiDocsLink": "API documentation",
+    "apiNoteSuffix": ". API extractions are tracked in your dashboard."
   },
   "extractors": {
     "loading": "Loading extractors...",

--- a/frontend/lib/i18n/es.json
+++ b/frontend/lib/i18n/es.json
@@ -49,7 +49,10 @@
     "submit": "Enviar",
     "reset": "Reiniciar",
     "extractionFailed": "La extracción falló",
-    "submissionFailed": "El envío falló"
+    "submissionFailed": "El envío falló",
+    "apiNote": "Para integrar la extracción en tus sistemas, consulta la",
+    "apiDocsLink": "documentación de la API",
+    "apiNoteSuffix": ". Las extracciones vía API se registran en tu dashboard."
   },
   "extractors": {
     "loading": "Cargando extractores...",

--- a/wiki/Arquitectura-Mínima-Operable.md
+++ b/wiki/Arquitectura-Mínima-Operable.md
@@ -41,7 +41,9 @@
 │  - POST /extraction/upload (fallback)   │
 │  - POST /extraction/extract             │
 │  - POST /extraction/submit              │
+│  - GET/POST/DELETE /tokens (API tokens) │
 │  - GET /extraction/metrics, logs, etc.  │
+│  - GET /api/docs (client API docs)      │
 └─────────────────────────────────────────┘
                    ↓
 ┌─────────────────────────────────────────┐

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -71,6 +71,7 @@ capstone-project/
 │   │   │   ├── api/admin/          # Rutas de administración (/admin/users)
 │   │   │   ├── api/extraction/     # Rutas HTTP y DTOs (/extraction)
 │   │   │   ├── api/extractors/     # Rutas HTTP (/extractors CRUD, AI, test)
+│   │   │   ├── api/tokens/        # Rutas HTTP (/tokens CRUD)
 │   │   │   ├── auth.py             # JWT y validación de tokens GitHub
 │   │   │   ├── ai_assist.py        # Generacion de schemas/prompts con Claude
 │   │   │   ├── database.py         # Configuracion PostgreSQL
@@ -94,6 +95,7 @@ capstone-project/
     │   ├── extractors/             # Gestion de extractores (CRUD + wizard)
     │   ├── dashboard/              # Dashboard
     │   ├── admin/users/            # Gestion de usuarios (admin)
+    │   ├── settings/tokens/       # Gestion de tokens API
     │   └── layout.tsx              # Layout con sidebar
     ├── auth.ts                     # Configuración NextAuth.js (GitHub OAuth)
     ├── middleware.ts               # Protección de rutas
@@ -147,8 +149,10 @@ capstone-project/
 - Versionado de extractores con soporte para pruebas A/B
 - Extracciones de prueba con registro detallado (*TestExtractionLog*)
 - Subida de archivos con *presigned URLs* (subida directa a S3, *fallback* via *backend*)
-- API REST con *endpoints* de extraccion, submission, extractores (CRUD), logs, metricas
-- *Frontend* con extraccion, gestion de extractores, visor de archivos y *dashboard*
+- Tokens API para acceso programatico con autenticacion *Bearer*
+- Documentacion de API filtrada para clientes en `/api/docs`
+- API REST con *endpoints* de extraccion, submission, extractores (CRUD), tokens, logs, metricas
+- *Frontend* con extraccion, gestion de extractores, tokens API, visor de archivos y *dashboard*
 - *React Query* para estado del servidor, *Zustand* para estado de UI
 - Base de datos *PostgreSQL* con migraciones *Alembic*
 - Seguimiento de llamadas a la API (*ApiCallLog*)
@@ -163,7 +167,8 @@ capstone-project/
 - [Repositorio Principal](https://github.com/mateonoel2/capstone-project)
 - [*Issues*](https://github.com/mateonoel2/capstone-project/issues)
 - [*Pull Requests*](https://github.com/mateonoel2/capstone-project/pulls)
-- [Documentación API](http://localhost:8000/docs) (cuando el *backend* está ejecutándose)
+- [Documentacion API (completa)](http://localhost:8000/docs) (cuando el *backend* esta ejecutandose)
+- [Documentacion API (clientes)](http://localhost:8000/api/docs) (vista filtrada para integracion programatica)
 
 ---
 
@@ -197,7 +202,8 @@ npm run dev
 
 - *Frontend*: http://localhost:3000
 - API: http://localhost:8000
-- Documentación API: http://localhost:8000/docs
+- Documentacion API (completa): http://localhost:8000/docs
+- Documentacion API (clientes): http://localhost:8000/api/docs
 
 ---
 

--- a/wiki/Últimas-Actualizaciones.md
+++ b/wiki/Últimas-Actualizaciones.md
@@ -2,6 +2,30 @@
 
 **Ultima actualizacion:** Marzo 2026
 
+## Actualizacion: Documentacion de API para Clientes (Marzo 2026)
+
+### Cambios principales
+
+- **Documentacion de API filtrada**: Nueva vista en `/api/docs` con *Swagger UI* que muestra unicamente los *endpoints* disponibles para integracion programatica (extraccion, extractores, tokens). La documentacion completa (incluyendo rutas internas y de admin) sigue disponible en `/docs`
+- **Spec *OpenAPI* filtrado**: `GET /api/openapi.json` retorna un *OpenAPI spec* que incluye solo los *endpoints* de cliente, con *schemas* no utilizados eliminados automaticamente
+- **Info banner en pagina principal**: La pagina de extraccion (`/`) ahora incluye un banner informativo que enlaza a la documentacion de la API y menciona que las extracciones via API se registran en el *dashboard* del usuario
+- **Metadata de la app actualizada**: Titulo y descripcion del *FastAPI* app actualizados a "Extracto API"
+
+---
+
+## Actualizacion: Tokens API para Acceso Programatico (Marzo 2026)
+
+### Cambios principales
+
+- **Tokens API**: Los usuarios pueden crear tokens para acceder a la API de extraccion desde *scripts* o integraciones sin necesidad de autenticarse via navegador. Autenticacion via *header* `Authorization: Bearer <token>`
+- **Gestion de tokens**: Nueva pagina `/settings/tokens` para crear, ver y revocar tokens. Soporte para expiracion opcional y seguimiento de ultimo uso
+- **Atribucion a usuario**: Las extracciones realizadas con un token API se registran en el *dashboard* del usuario dueno del token, igual que las extracciones via interfaz web
+- **Nuevos *endpoints***: `GET /tokens`, `POST /tokens`, `DELETE /tokens/{token_id}`
+- **Modelo `ApiToken`**: Nueva tabla con *hash* del token, nombre, expiracion, estado de revocacion y ultimo uso
+- **Sidebar actualizado**: Nueva entrada "Tokens API" en la navegacion
+
+---
+
 ## Actualizacion: Autenticacion y *Multi-tenancy* (Marzo 2026)
 
 ### Cambios principales
@@ -170,8 +194,12 @@ GET  /admin/users                - Listar usuarios (admin)
 POST /admin/users                - Crear usuario (admin)
 PUT  /admin/users/{id}           - Actualizar usuario (admin)
 DELETE /admin/users/{id}         - Eliminar usuario (admin)
+GET  /tokens                    - Listar tokens API del usuario
+POST /tokens                    - Crear token API
+DELETE /tokens/{id}             - Revocar token API
 GET  /health                    - Verificacion de salud
-GET  /docs                      - Documentacion interactiva
+GET  /docs                      - Documentacion interactiva (completa)
+GET  /api/docs                  - Documentacion de API para clientes (filtrada)
 ```
 
 ## Cómo Usar


### PR DESCRIPTION
## Summary
- Add filtered OpenAPI spec served at `/api/docs` showing only client-facing endpoints (extraction, extractors, tokens) — keeps internal/admin routes hidden from API clients
- Add info banner on the home page (extraction page) linking to the API docs and noting that API extractions count towards the user's dashboard metrics
- Update app metadata from "Bank Statement Extraction API" to "Extracto API"
- Update docs (CLAUDE.md, README.md, wiki) to reflect API tokens and client docs features

## Detalle

### Backend (`main.py`)
- `CLIENT_ENDPOINT_WHITELIST` — 13 client-facing endpoints
- `get_client_openapi_schema()` — deep-copies full spec, filters to whitelist, prunes unused schemas transitively
- `GET /api/openapi.json` + `GET /api/docs` — hidden from main docs, serve filtered Swagger UI
- Root endpoint (`/`) now includes `client_docs` link

### Frontend
- Info banner below extraction page subtitle with link to `/api/docs`
- i18n keys added for ES and EN

### Docs
- CLAUDE.md: added tokens routes, client API docs, `/settings/tokens` page
- README.md: added API tokens and client docs to features list, tokens route to project structure
- Wiki: new entries in Últimas Actualizaciones, updated Home.md and Arquitectura

## Test plan
- [ ] Visit `/api/docs` — only client endpoints appear (no admin, auth, internal)
- [ ] Visit `/docs` — still shows all endpoints
- [ ] Home page shows info banner with link to API docs
- [ ] Link opens client docs in new tab
- [ ] `ruff check` and `pytest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)