### PR TITLE
Add WebP image support for extraction

### DIFF
--- a/backend/src/infrastructure/extractors/statement_extractor.py
+++ b/backend/src/infrastructure/extractors/statement_extractor.py
@@ -13,7 +13,7 @@ from src.core.logger import get_logger
 
 logger = get_logger(__name__)
 
-IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png"}
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp"}
 PDF_EXTENSIONS = {".pdf"}
 SUPPORTED_EXTENSIONS = PDF_EXTENSIONS | IMAGE_EXTENSIONS
 

--- a/frontend/components/file-upload.tsx
+++ b/frontend/components/file-upload.tsx
@@ -8,6 +8,7 @@ const ACCEPTED_TYPES = [
   "application/pdf",
   "image/jpeg",
   "image/png",
+  "image/webp",
 ];
 
 interface FileUploadProps {
@@ -47,7 +48,7 @@ export function FileUpload({ onFileSelect, isLoading }: FileUploadProps) {
     >
       <input
         type="file"
-        accept=".pdf,.jpg,.jpeg,.png"
+        accept=".pdf,.jpg,.jpeg,.png,.webp"
         onChange={handleFileInput}
         className="hidden"
         id="file-upload"

--- a/frontend/lib/i18n/en.json
+++ b/frontend/lib/i18n/en.json
@@ -130,7 +130,7 @@
   "fileUpload": {
     "processing": "Processing...",
     "dragOrClick": "Drag your file here or click to browse",
-    "acceptedFormats": "PDF, JPG or PNG"
+    "acceptedFormats": "PDF, JPG, PNG or WebP"
   },
   "extractionTable": {
     "corrected": "Corrected",

--- a/frontend/lib/i18n/es.json
+++ b/frontend/lib/i18n/es.json
@@ -130,7 +130,7 @@
   "fileUpload": {
     "processing": "Procesando...",
     "dragOrClick": "Arrastra tu archivo aquí o haz clic para buscar",
-    "acceptedFormats": "PDF, JPG o PNG"
+    "acceptedFormats": "PDF, JPG, PNG o WebP"
   },
   "extractionTable": {
     "corrected": "Corregido",


### PR DESCRIPTION
## Summary
- Add `.webp` to supported image extensions in the backend extractor
- Add `image/webp` MIME type and `.webp` extension to the frontend file upload component
- Update accepted formats text in both Spanish and English i18n files

## Test plan
- [x] Upload a `.webp` file and verify it can be selected in the file picker
- [x] Verify extraction works correctly with a WebP image
- [ ] Verify drag-and-drop works with WebP files

🤖 Generated with [Claude Code](https://claude.com/claude-code)