### PR TITLE
Open CORS for API tokens, fix guest role persistence

### DIFF
--- a/backend/alembic/versions/m3h4i5j6k7l8_change_user_role_default_to_guest.py
+++ b/backend/alembic/versions/m3h4i5j6k7l8_change_user_role_default_to_guest.py
@@ -5,8 +5,6 @@ Revises: l2g3h4i5j6k7
 Create Date: 2026-03-25
 """
 
-import sqlalchemy as sa
-
 from alembic import op
 
 revision = "m3h4i5j6k7l8"

--- a/backend/alembic/versions/m3h4i5j6k7l8_change_user_role_default_to_guest.py
+++ b/backend/alembic/versions/m3h4i5j6k7l8_change_user_role_default_to_guest.py
@@ -1,0 +1,23 @@
+"""Change user role server_default from 'user' to 'guest'
+
+Revision ID: m3h4i5j6k7l8
+Revises: l2g3h4i5j6k7
+Create Date: 2026-03-25
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "m3h4i5j6k7l8"
+down_revision = "l2g3h4i5j6k7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("users", "role", server_default="guest")
+
+
+def downgrade() -> None:
+    op.alter_column("users", "role", server_default="user")

--- a/backend/alembic/versions/m3h4i5j6k7l8_change_user_role_default_to_guest.py
+++ b/backend/alembic/versions/m3h4i5j6k7l8_change_user_role_default_to_guest.py
@@ -14,8 +14,10 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.alter_column("users", "role", server_default="guest")
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column("role", server_default="guest")
 
 
 def downgrade() -> None:
-    op.alter_column("users", "role", server_default="user")
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column("role", server_default="user")

--- a/backend/src/infrastructure/api/admin/routes.py
+++ b/backend/src/infrastructure/api/admin/routes.py
@@ -57,7 +57,7 @@ async def create_user(request: CreateUserRequest, admin: AdminDep, db: DbDep):
     existing = repo.get_by_github_username(request.github_username)
     if existing:
         raise HTTPException(status_code=409, detail="El usuario ya existe")
-    if request.role not in ("user", "admin"):
+    if request.role not in ("user", "admin", "guest"):
         raise HTTPException(status_code=400, detail="Rol inválido")
     user = repo.create(request.github_username, request.role)
     return UserResponse(
@@ -76,7 +76,7 @@ async def update_user(user_id: int, request: UpdateUserRequest, admin: AdminDep,
     repo = UserRepository(db)
     fields = {}
     if request.role is not None:
-        if request.role not in ("user", "admin"):
+        if request.role not in ("user", "admin", "guest"):
             raise HTTPException(status_code=400, detail="Rol inválido")
         fields["role"] = request.role
     if request.is_active is not None:

--- a/backend/src/infrastructure/models.py
+++ b/backend/src/infrastructure/models.py
@@ -27,7 +27,7 @@ class User(Base):
     github_username = Column(String(100), unique=True, nullable=False)
     email = Column(String(255), nullable=True)
     avatar_url = Column(String(500), nullable=True)
-    role = Column(String(20), nullable=False, default="user")
+    role = Column(String(20), nullable=False, default="guest")
     is_active = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     last_login_at = Column(DateTime, nullable=True)

--- a/backend/src/infrastructure/repository.py
+++ b/backend/src/infrastructure/repository.py
@@ -523,7 +523,7 @@ class UserRepository:
         users = self.session.query(User).order_by(User.id).all()
         return [self._to_entity(u) for u in users]
 
-    def create(self, github_username: str, role: str = "user") -> UserData:
+    def create(self, github_username: str, role: str = "guest") -> UserData:
         user = User(github_username=github_username, role=role)
         self.session.add(user)
         self.session.commit()

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -72,9 +72,7 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
                 resp.headers["Access-Control-Allow-Methods"] = (
                     "GET, POST, PUT, DELETE, PATCH, OPTIONS"
                 )
-                resp.headers["Access-Control-Allow-Headers"] = (
-                    "Authorization, Content-Type"
-                )
+                resp.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
                 resp.headers["Access-Control-Max-Age"] = "600"
                 resp.headers["Vary"] = "Origin"
             return resp

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -11,10 +11,10 @@ sys.path.insert(0, str(project_root))
 from alembic.config import Config
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import HTMLResponse, JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
 
 from alembic import command
 from src.core.logger import get_logger
@@ -43,6 +43,50 @@ def _get_allowed_origins() -> list[str]:
     if origins:
         return [o.strip() for o in origins.split(",") if o.strip()]
     return ["http://localhost:3000", "https://capstone-project-sigma-one.vercel.app"]
+
+
+class DynamicCORSMiddleware(BaseHTTPMiddleware):
+    """CORS middleware that allows any origin for API-token auth.
+
+    First-party origins (ALLOWED_ORIGINS) get ``Access-Control-Allow-Credentials``
+    so the browser can attach cookies/session headers.  Any other origin is still
+    allowed (the ``Origin`` header is reflected back) but *without* credentials —
+    those callers are expected to use an ``Authorization: Bearer exto_…`` API token,
+    which is the real security boundary.
+    """
+
+    def __init__(self, app, allowed_origins: list[str]):
+        super().__init__(app)
+        self.allowed_origins: set[str] = set(allowed_origins)
+
+    async def dispatch(self, request: Request, call_next):
+        origin = request.headers.get("origin", "")
+
+        # --- Preflight (OPTIONS) -------------------------------------------------
+        if request.method == "OPTIONS":
+            resp = Response(status_code=204)
+            if origin:
+                resp.headers["Access-Control-Allow-Origin"] = origin
+                if origin in self.allowed_origins:
+                    resp.headers["Access-Control-Allow-Credentials"] = "true"
+                resp.headers["Access-Control-Allow-Methods"] = (
+                    "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+                )
+                resp.headers["Access-Control-Allow-Headers"] = (
+                    "Authorization, Content-Type"
+                )
+                resp.headers["Access-Control-Max-Age"] = "600"
+                resp.headers["Vary"] = "Origin"
+            return resp
+
+        # --- Actual request -------------------------------------------------------
+        response = await call_next(request)
+        if origin:
+            response.headers["Access-Control-Allow-Origin"] = origin
+            if origin in self.allowed_origins:
+                response.headers["Access-Control-Allow-Credentials"] = "true"
+            response.headers["Vary"] = "Origin"
+        return response
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -76,13 +120,7 @@ app = FastAPI(
 )
 
 app.add_middleware(SecurityHeadersMiddleware)
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_get_allowed_origins(),
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+app.add_middleware(DynamicCORSMiddleware, allowed_origins=_get_allowed_origins())
 
 app.include_router(auth_router)
 app.include_router(admin_router)

--- a/backend/src/tests/test_quota.py
+++ b/backend/src/tests/test_quota.py
@@ -1,0 +1,129 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.domain.entities import QuotaExceededError, UserData
+from src.domain.services.quota import (
+    GUEST_DAILY_AI_PROMPTS,
+    GUEST_DAILY_EXTRACTIONS,
+    GUEST_MAX_EXTRACTORS,
+    QuotaService,
+)
+
+
+def _make_user(role: str = "guest", user_id: int = 1) -> UserData:
+    return UserData(
+        id=user_id,
+        github_id=None,
+        github_username="testuser",
+        email=None,
+        avatar_url=None,
+        role=role,
+        is_active=True,
+    )
+
+
+def _make_service(
+    extractions_today: int = 0,
+    extractors_count: int = 0,
+    ai_prompts_today: int = 0,
+) -> QuotaService:
+    api_call_repo = MagicMock()
+    api_call_repo.count_today.return_value = extractions_today
+
+    extractor_repo = MagicMock()
+    extractor_repo.count_by_user.return_value = extractors_count
+
+    ai_usage_repo = MagicMock()
+    ai_usage_repo.count_today.return_value = ai_prompts_today
+
+    return QuotaService(
+        api_call_repo=api_call_repo,
+        extractor_repo=extractor_repo,
+        ai_usage_repo=ai_usage_repo,
+    )
+
+
+# --- Extraction quota ---
+
+
+class TestExtractionQuota:
+    def test_guest_under_limit_allowed(self):
+        service = _make_service(extractions_today=GUEST_DAILY_EXTRACTIONS - 1)
+        service.check_extraction_quota(_make_user("guest"))
+
+    def test_guest_at_limit_raises(self):
+        service = _make_service(extractions_today=GUEST_DAILY_EXTRACTIONS)
+        with pytest.raises(QuotaExceededError):
+            service.check_extraction_quota(_make_user("guest"))
+
+    def test_guest_over_limit_raises(self):
+        service = _make_service(extractions_today=GUEST_DAILY_EXTRACTIONS + 5)
+        with pytest.raises(QuotaExceededError):
+            service.check_extraction_quota(_make_user("guest"))
+
+    def test_regular_user_no_limit(self):
+        service = _make_service(extractions_today=1000)
+        service.check_extraction_quota(_make_user("user"))
+
+    def test_admin_no_limit(self):
+        service = _make_service(extractions_today=1000)
+        service.check_extraction_quota(_make_user("admin"))
+
+
+# --- Extractor create quota ---
+
+
+class TestExtractorCreateQuota:
+    def test_guest_under_limit_allowed(self):
+        service = _make_service(extractors_count=0)
+        service.check_extractor_create_quota(_make_user("guest"))
+
+    def test_guest_at_limit_raises(self):
+        service = _make_service(extractors_count=GUEST_MAX_EXTRACTORS)
+        with pytest.raises(QuotaExceededError):
+            service.check_extractor_create_quota(_make_user("guest"))
+
+    def test_regular_user_no_limit(self):
+        service = _make_service(extractors_count=100)
+        service.check_extractor_create_quota(_make_user("user"))
+
+
+# --- AI prompt quota ---
+
+
+class TestAiPromptQuota:
+    def test_guest_under_limit_allowed(self):
+        service = _make_service(ai_prompts_today=GUEST_DAILY_AI_PROMPTS - 1)
+        service.check_ai_prompt_quota(_make_user("guest"))
+
+    def test_guest_at_limit_raises(self):
+        service = _make_service(ai_prompts_today=GUEST_DAILY_AI_PROMPTS)
+        with pytest.raises(QuotaExceededError):
+            service.check_ai_prompt_quota(_make_user("guest"))
+
+    def test_regular_user_no_limit(self):
+        service = _make_service(ai_prompts_today=1000)
+        service.check_ai_prompt_quota(_make_user("user"))
+
+
+# --- Usage report ---
+
+
+class TestGetUsage:
+    def test_guest_returns_limits(self):
+        service = _make_service(extractions_today=3, extractors_count=1, ai_prompts_today=5)
+        usage = service.get_usage(_make_user("guest"))
+
+        assert usage["unlimited"] is False
+        assert usage["extractions"] == {"used": 3, "limit": GUEST_DAILY_EXTRACTIONS}
+        assert usage["extractors"] == {"used": 1, "limit": GUEST_MAX_EXTRACTORS}
+        assert usage["ai_prompts"] == {"used": 5, "limit": GUEST_DAILY_AI_PROMPTS}
+
+    def test_regular_user_unlimited(self):
+        usage = _make_service().get_usage(_make_user("user"))
+        assert usage == {"unlimited": True}
+
+    def test_admin_unlimited(self):
+        usage = _make_service().get_usage(_make_user("admin"))
+        assert usage == {"unlimited": True}

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -100,6 +100,7 @@ export default function AdminUsersPage() {
               >
                 <option value="user">{t("admin.roleUser")}</option>
                 <option value="admin">{t("admin.roleAdmin")}</option>
+                <option value="guest">{t("admin.roleGuest")}</option>
               </select>
             </div>
             <button
@@ -175,6 +176,7 @@ export default function AdminUsersPage() {
                     >
                       <option value="user">{t("admin.roleUser")}</option>
                       <option value="admin">{t("admin.roleAdmin")}</option>
+                      <option value="guest">{t("admin.roleGuest")}</option>
                     </select>
                   </td>
                   <td className="whitespace-nowrap px-6 py-4">

--- a/frontend/lib/i18n/en.json
+++ b/frontend/lib/i18n/en.json
@@ -112,6 +112,7 @@
     "role": "Role",
     "roleUser": "User",
     "roleAdmin": "Admin",
+    "roleGuest": "Guest",
     "creating": "Creating...",
     "create": "Create",
     "cancel": "Cancel",

--- a/frontend/lib/i18n/es.json
+++ b/frontend/lib/i18n/es.json
@@ -112,6 +112,7 @@
     "role": "Rol",
     "roleUser": "Usuario",
     "roleAdmin": "Admin",
+    "roleGuest": "Invitado",
     "creating": "Creando...",
     "create": "Crear",
     "cancel": "Cancelar",


### PR DESCRIPTION
## Summary
- Replace static `CORSMiddleware` with a custom `DynamicCORSMiddleware` that reflects any `Origin` header back, enabling third-party frontends to call the API using their own tokens
- First-party origins still receive `Access-Control-Allow-Credentials: true` for session-based auth
- Fix guest role persistence: new users were defaulting to `user` instead of `guest` in the model/repository defaults and the database `server_default`
- Allow admins to set users back to `guest` role from the admin panel
- Add quota tests to ensure guest daily limits are enforced (extractions, extractors, AI prompts)

## Test plan
- [x] Verify first-party frontend (localhost:3000, Vercel) works as before with credentials
- [x] Test cross-origin fetch from a different domain using an API token — should succeed
- [x] Verify preflight (OPTIONS) requests return correct CORS headers
- [x] New GitHub user auto-registers as `guest` (not `user`)
- [x] Admin can change a user's role to `guest` from the dropdown
- [ ] Guest quotas are enforced (14 unit tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)