### PR TITLE
Add default receipt extractor, fix Swagger CSP, show fields preview

### DIFF
--- a/backend/alembic/versions/n4i5j6k7l8m9_add_default_receipt_extractor.py
+++ b/backend/alembic/versions/n4i5j6k7l8m9_add_default_receipt_extractor.py
@@ -1,0 +1,107 @@
+"""Add default receipt extractor for existing users without extractors
+
+Revision ID: n4i5j6k7l8m9
+Revises: m3h4i5j6k7l8
+Create Date: 2026-03-25
+"""
+
+import json
+
+from sqlalchemy import text
+
+from alembic import op
+
+revision = "n4i5j6k7l8m9"
+down_revision = "m3h4i5j6k7l8"
+branch_labels = None
+depends_on = None
+
+DEFAULT_RECEIPT_SCHEMA = json.dumps(
+    {
+        "type": "object",
+        "properties": {
+            "comercio": {"type": "string", "description": "Nombre del comercio o negocio"},
+            "fecha": {
+                "type": "string",
+                "description": "Fecha de la compra (formato YYYY-MM-DD)",
+            },
+            "productos": {
+                "type": "array",
+                "description": "Lista de productos o servicios",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "nombre": {
+                            "type": "string",
+                            "description": "Nombre del producto o servicio",
+                        },
+                        "cantidad": {"type": "number", "description": "Cantidad comprada"},
+                        "precio_unitario": {
+                            "type": "number",
+                            "description": "Precio por unidad",
+                        },
+                    },
+                    "required": ["nombre", "cantidad", "precio_unitario"],
+                },
+            },
+            "subtotal": {"type": "number", "description": "Subtotal antes de impuestos"},
+            "impuesto": {
+                "type": "number",
+                "description": "Monto del impuesto (IVA u otro)",
+            },
+            "total": {"type": "number", "description": "Total de la compra"},
+            "metodo_pago": {
+                "type": "string",
+                "description": "Método de pago (efectivo, tarjeta, etc.)",
+            },
+        },
+        "required": ["comercio", "fecha", "total"],
+    }
+)
+
+DEFAULT_PROMPT = (
+    "Extrae la información de esta boleta o recibo de compra. "
+    "Si algún campo no está presente en el documento, devuelve null para ese campo. "
+    "Para los productos, extrae cada línea con su nombre, cantidad y precio unitario."
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # Find users that have no extractor configs
+    users_without_extractors = conn.execute(
+        text("""
+            SELECT u.id FROM users u
+            WHERE NOT EXISTS (
+                SELECT 1 FROM extractor_configs ec WHERE ec.user_id = u.id
+            )
+        """)
+    ).fetchall()
+
+    for (user_id,) in users_without_extractors:
+        conn.execute(
+            text("""
+                INSERT INTO extractor_configs
+                    (name, description, prompt, model, output_schema, is_default, status, user_id,
+                     created_at, updated_at)
+                VALUES
+                    ('Boletas y recibos',
+                     'Extrae información de boletas, recibos de compra y tickets de venta',
+                     :prompt, 'claude-haiku-4-5-20251001', :schema,
+                     true, 'active', :user_id, NOW(), NOW())
+            """),
+            {"prompt": DEFAULT_PROMPT, "schema": DEFAULT_RECEIPT_SCHEMA, "user_id": user_id},
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        text("""
+            DELETE FROM extractor_configs
+            WHERE name = 'Boletas y recibos'
+            AND NOT EXISTS (
+                SELECT 1 FROM extraction_logs el WHERE el.extractor_config_id = extractor_configs.id
+            )
+        """)
+    )

--- a/backend/src/domain/constants.py
+++ b/backend/src/domain/constants.py
@@ -1,3 +1,5 @@
+from src.domain.entities import ExtractorConfigData
+
 UNKNOWN_OWNER = "Unknown"
 UNKNOWN_BANK = "Unknown"
 UNKNOWN_ACCOUNT = "000000000000000000"
@@ -88,3 +90,69 @@ BANK_DICT_KUSHKI = {
     "VECTOR": "0080",
     "VOLKSWAGEN": "0081",
 }
+
+DEFAULT_RECEIPT_EXTRACTOR = ExtractorConfigData(
+    id=None,
+    name="Boletas y recibos",
+    description="Extrae información de boletas, recibos de compra y tickets de venta",
+    prompt=(
+        "Extrae la información de esta boleta o recibo de compra. "
+        "Si algún campo no está presente en el documento, devuelve null para ese campo. "
+        "Para los productos, extrae cada línea con su nombre, cantidad y precio unitario."
+    ),
+    model="claude-haiku-4-5-20251001",
+    output_schema={
+        "type": "object",
+        "properties": {
+            "comercio": {
+                "type": "string",
+                "description": "Nombre del comercio o negocio",
+            },
+            "fecha": {
+                "type": "string",
+                "description": "Fecha de la compra (formato YYYY-MM-DD)",
+            },
+            "productos": {
+                "type": "array",
+                "description": "Lista de productos o servicios",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "nombre": {
+                            "type": "string",
+                            "description": "Nombre del producto o servicio",
+                        },
+                        "cantidad": {
+                            "type": "number",
+                            "description": "Cantidad comprada",
+                        },
+                        "precio_unitario": {
+                            "type": "number",
+                            "description": "Precio por unidad",
+                        },
+                    },
+                    "required": ["nombre", "cantidad", "precio_unitario"],
+                },
+            },
+            "subtotal": {
+                "type": "number",
+                "description": "Subtotal antes de impuestos",
+            },
+            "impuesto": {
+                "type": "number",
+                "description": "Monto del impuesto (IVA u otro)",
+            },
+            "total": {
+                "type": "number",
+                "description": "Total de la compra",
+            },
+            "metodo_pago": {
+                "type": "string",
+                "description": "Método de pago (efectivo, tarjeta, etc.)",
+            },
+        },
+        "required": ["comercio", "fecha", "total"],
+    },
+    is_default=True,
+    status="active",
+)

--- a/backend/src/infrastructure/api/auth/routes.py
+++ b/backend/src/infrastructure/api/auth/routes.py
@@ -1,9 +1,12 @@
+from dataclasses import replace
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from src.domain.constants import DEFAULT_RECEIPT_EXTRACTOR
+from src.domain.services.extractor_config import ExtractorConfigService
 from src.domain.services.quota import QuotaService
 from src.infrastructure.auth import UserDep, create_access_token, validate_github_token
 from src.infrastructure.database import get_db
@@ -17,6 +20,12 @@ from src.infrastructure.repository import (
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 DbDep = Annotated[Session, Depends(get_db)]
+
+
+def _create_default_extractor(db: Session, user_id: int) -> None:
+    """Crea el extractor default de boletas para un usuario nuevo."""
+    service = ExtractorConfigService(ExtractorConfigRepository(db))
+    service.create(replace(DEFAULT_RECEIPT_EXTRACTOR), user_id=user_id)
 
 
 class LoginRequest(BaseModel):
@@ -55,6 +64,7 @@ async def login(request: LoginRequest, db: DbDep):
         if not user:
             # Auto-register as guest
             user = repo.create(github_username=github_username, role="guest")
+            _create_default_extractor(db, user.id)
         # First login — fill in github_id and profile info
         repo.update_login_info(user.id, github_id, email, avatar_url)
         user = repo.get_by_id(user.id)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -90,6 +90,16 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Adds security headers to all responses (HSTS, CSP, X-Content-Type-Options, etc.)."""
 
+    DOCS_PATHS = {"/docs", "/api/docs", "/redoc"}
+    DOCS_CSP = (
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+        "img-src 'self' data: https://cdn.jsdelivr.net; "
+        "frame-ancestors 'none'"
+    )
+    DEFAULT_CSP = "default-src 'self'; frame-ancestors 'none'"
+
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
         response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
@@ -97,7 +107,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["X-XSS-Protection"] = "1; mode=block"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-        response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none'"
+        if request.url.path in self.DOCS_PATHS:
+            response.headers["Content-Security-Policy"] = self.DOCS_CSP
+        else:
+            response.headers["Content-Security-Policy"] = self.DEFAULT_CSP
         return response
 
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -218,6 +218,38 @@ export default function Home() {
               ))}
             </SelectContent>
           </Select>
+
+          {selectedConfig && (() => {
+            const schema = selectedConfig.output_schema as { properties?: Record<string, { type?: string; description?: string }>; required?: string[] };
+            const properties = schema?.properties || {};
+            const required = new Set(schema?.required || []);
+            const fieldNames = Object.keys(properties).filter((k) => k !== "is_valid_document");
+            if (fieldNames.length === 0) return null;
+            return (
+              <div className="mt-3 rounded-lg border border-gray-200 bg-white p-3">
+                {selectedConfig.description && (
+                  <p className="text-sm text-gray-600 mb-2">{selectedConfig.description}</p>
+                )}
+                <p className="text-xs font-medium text-gray-500 mb-2">{t("extraction.fieldsToExtract")}</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {fieldNames.map((field) => (
+                    <span
+                      key={field}
+                      className="inline-flex items-center gap-1 rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-700"
+                      title={properties[field]?.description || ""}
+                    >
+                      {field.replace(/_/g, " ")}
+                      {required.has(field) && (
+                        <span className="text-[10px] text-blue-600 font-medium">
+                          ({t("extraction.requiredField")})
+                        </span>
+                      )}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
         </div>
 
         {!file ? (

--- a/frontend/lib/i18n/en.json
+++ b/frontend/lib/i18n/en.json
@@ -54,6 +54,9 @@
     "uploading": "Uploading file...",
     "extractionFailed": "Extraction failed",
     "submissionFailed": "Submission failed",
+    "fieldsToExtract": "Fields to extract",
+    "requiredField": "required",
+    "noFieldsConfigured": "This extractor has no configured fields.",
     "apiNote": "To integrate extraction into your systems, see the",
     "apiDocsLink": "API documentation",
     "apiNoteSuffix": ". API extractions are tracked in your dashboard."

--- a/frontend/lib/i18n/es.json
+++ b/frontend/lib/i18n/es.json
@@ -54,6 +54,9 @@
     "uploading": "Subiendo archivo...",
     "extractionFailed": "La extracción falló",
     "submissionFailed": "El envío falló",
+    "fieldsToExtract": "Campos a extraer",
+    "requiredField": "requerido",
+    "noFieldsConfigured": "Este extractor no tiene campos configurados.",
     "apiNote": "Para integrar la extracción en tus sistemas, consulta la",
     "apiDocsLink": "documentación de la API",
     "apiNoteSuffix": ". Las extracciones vía API se registran en tu dashboard."


### PR DESCRIPTION
## Summary
- New users automatically get a "Boletas y recibos" default extractor on registration, so they can start extracting immediately
- Data migration backfills the default extractor for existing users without any extractors (prod)
- Extraction page now shows the fields the selected extractor will extract (with description, badges, required markers)
- Fix CSP blocking Swagger UI in production (`/docs`, `/api/docs`) by allowing `cdn.jsdelivr.net` and inline scripts on docs routes only

## Test plan
- [x] Backend: 100 tests pass, ruff clean
- [x] Frontend: eslint clean (0 errors)
- [ ] Verify new user registration creates the default extractor
- [ ] Verify fields preview updates when switching extractors
- [ ] Verify Swagger UI loads on production `/docs` and `/api/docs`
- [ ] Verify data migration creates extractor for existing users without one

🤖 Generated with [Claude Code](https://claude.com/claude-code)