### PR TITLE
Fix extractor scoping and backfill receipt extractor

### DIFF
--- a/backend/alembic/versions/p6q7r8s9t0u1_backfill_receipt_extractor.py
+++ b/backend/alembic/versions/p6q7r8s9t0u1_backfill_receipt_extractor.py
@@ -1,0 +1,115 @@
+"""Backfill receipt extractor for users missing it
+
+Revision ID: p6q7r8s9t0u1
+Revises: o5p6q7r8s9t0
+Create Date: 2026-03-25
+"""
+
+import json
+
+from sqlalchemy import text
+
+from alembic import op
+
+revision = "p6q7r8s9t0u1"
+down_revision = "o5p6q7r8s9t0"
+branch_labels = None
+depends_on = None
+
+DEFAULT_RECEIPT_SCHEMA = json.dumps(
+    {
+        "type": "object",
+        "properties": {
+            "comercio": {"type": "string", "description": "Nombre del comercio o negocio"},
+            "fecha": {
+                "type": "string",
+                "description": "Fecha de la compra (formato YYYY-MM-DD)",
+            },
+            "productos": {
+                "type": "array",
+                "description": "Lista de productos o servicios",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "nombre": {
+                            "type": "string",
+                            "description": "Nombre del producto o servicio",
+                        },
+                        "cantidad": {"type": "number", "description": "Cantidad comprada"},
+                        "precio_unitario": {
+                            "type": "number",
+                            "description": "Precio por unidad",
+                        },
+                    },
+                    "required": ["nombre", "cantidad", "precio_unitario"],
+                },
+            },
+            "subtotal": {"type": "number", "description": "Subtotal antes de impuestos"},
+            "impuesto": {
+                "type": "number",
+                "description": "Monto del impuesto (IVA u otro)",
+            },
+            "total": {"type": "number", "description": "Total de la compra"},
+            "metodo_pago": {
+                "type": "string",
+                "description": "Método de pago (efectivo, tarjeta, etc.)",
+            },
+        },
+        "required": ["comercio", "fecha", "total"],
+    }
+)
+
+DEFAULT_PROMPT = (
+    "Extrae la información de esta boleta o recibo de compra. "
+    "Si algún campo no está presente en el documento, devuelve null para ese campo. "
+    "Para los productos, extrae cada línea con su nombre, cantidad y precio unitario."
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # Find users that don't have a "Boletas y recibos" extractor
+    users_missing = conn.execute(
+        text("""
+            SELECT u.id FROM users u
+            WHERE NOT EXISTS (
+                SELECT 1 FROM extractor_configs ec
+                WHERE ec.user_id = u.id
+                AND ec.name = 'Boletas y recibos'
+            )
+        """)
+    ).fetchall()
+
+    for (user_id,) in users_missing:
+        # Check if user already has a default extractor
+        has_default = conn.execute(
+            text("""
+                SELECT 1 FROM extractor_configs
+                WHERE user_id = :user_id AND is_default = true
+                LIMIT 1
+            """),
+            {"user_id": user_id},
+        ).fetchone()
+
+        conn.execute(
+            text("""
+                INSERT INTO extractor_configs
+                    (name, description, prompt, model, output_schema, is_default, status, user_id,
+                     created_at, updated_at)
+                VALUES
+                    ('Boletas y recibos',
+                     'Extrae información de boletas, recibos de compra y tickets de venta',
+                     :prompt, 'claude-haiku-4-5-20251001', :schema,
+                     :is_default, 'active', :user_id, NOW(), NOW())
+            """),
+            {
+                "prompt": DEFAULT_PROMPT,
+                "schema": DEFAULT_RECEIPT_SCHEMA,
+                "user_id": user_id,
+                "is_default": not has_default,
+            },
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/src/infrastructure/api/extractors/routes.py
+++ b/backend/src/infrastructure/api/extractors/routes.py
@@ -96,9 +96,8 @@ def _check_ownership(config: ExtractorConfigData, user: UserData) -> None:
 
 @router.get("", response_model=ExtractorConfigListResponse)
 async def list_extractor_configs(db: DbDep, user: UserDep, status: str | None = None):
-    user_filter = None if user.role == "admin" else user.id
     service = _get_service(db)
-    configs = service.get_all(status=status, user_id=user_filter)
+    configs = service.get_all(status=status, user_id=user.id)
     return ExtractorConfigListResponse(
         configs=[ExtractorConfigResponse.model_validate(c) for c in configs]
     )

--- a/frontend/app/extractors/page.tsx
+++ b/frontend/app/extractors/page.tsx
@@ -100,17 +100,19 @@ export default function ExtractorsPage() {
                         </span>
                       </div>
                       <div className="flex items-center gap-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="text-red-600 hover:text-red-700"
-                          onClick={(e) => {
-                            e.preventDefault();
-                            handleDelete(config.id);
-                          }}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
+                        {!config.is_default && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="text-red-600 hover:text-red-700"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              handleDelete(config.id);
+                            }}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        )}
                       </div>
                     </div>
                     {config.description && (


### PR DESCRIPTION
## Summary
- Admin now sees only their own extractors on the extractors page (dashboard still shows all users' data)
- Restore `is_default` delete protection — default extractors can't be deleted (trash icon hidden)
- New migration backfills "Boletas y recibos" for users who don't have one yet (e.g., admin), with `is_default=false` if user already has a default extractor

## Test plan
- [x] 100 backend tests pass
- [x] Ruff + ESLint clean
- [ ] Verify admin only sees own extractors on /extractors page
- [ ] Verify admin still sees all users' data on /dashboard
- [ ] Verify admin gets "Boletas y recibos" after migration runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)