### PR TITLE
Migrate database from Integer to UUID primary keys

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -2,7 +2,7 @@
 script_location = alembic
 prepend_sys_path = .
 version_path_separator = os
-sqlalchemy.url = sqlite:///data/extractions.db
+sqlalchemy.url = postgresql://postgres:postgres@localhost:5432/extractions
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/alembic/versions/q7r8s9t0u1v2_migrate_to_uuid_pks.py
+++ b/backend/alembic/versions/q7r8s9t0u1v2_migrate_to_uuid_pks.py
@@ -1,0 +1,252 @@
+"""Migrate all tables from Integer PKs to UUID PKs.
+
+Revision ID: q7r8s9t0u1v2
+Revises: p6q7r8s9t0u1
+Create Date: 2026-03-25 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "q7r8s9t0u1v2"
+down_revision = "p6q7r8s9t0u1"
+branch_labels = None
+depends_on = None
+
+# All tables that need PK migration
+ALL_TABLES = [
+    "users",
+    "api_tokens",
+    "extractor_configs",
+    "extractor_config_versions",
+    "extraction_logs",
+    "test_extraction_logs",
+    "api_call_logs",
+    "ai_usage_logs",
+    "audit_logs",
+    "data_consents",
+]
+
+# FK relationships: (child_table, fk_column, parent_table, parent_column, nullable, ondelete)
+FK_RELATIONSHIPS = [
+    ("api_tokens", "user_id", "users", "id", False, "CASCADE"),
+    ("extractor_configs", "user_id", "users", "id", True, None),
+    ("extractor_config_versions", "extractor_config_id", "extractor_configs", "id", False, None),
+    ("extraction_logs", "user_id", "users", "id", True, None),
+    ("extraction_logs", "extractor_config_id", "extractor_configs", "id", True, None),
+    (
+        "extraction_logs",
+        "extractor_config_version_id",
+        "extractor_config_versions",
+        "id",
+        True,
+        None,
+    ),
+    ("test_extraction_logs", "user_id", "users", "id", True, None),
+    ("test_extraction_logs", "extractor_config_id", "extractor_configs", "id", True, "SET NULL"),
+    ("api_call_logs", "user_id", "users", "id", True, None),
+    ("api_call_logs", "extractor_config_id", "extractor_configs", "id", True, None),
+    (
+        "api_call_logs",
+        "extractor_config_version_id",
+        "extractor_config_versions",
+        "id",
+        True,
+        None,
+    ),
+    ("ai_usage_logs", "user_id", "users", "id", False, None),
+    ("audit_logs", "user_id", "users", "id", True, None),
+    ("data_consents", "user_id", "users", "id", False, "CASCADE"),
+]
+
+
+def upgrade() -> None:
+    # Ensure gen_random_uuid() is available
+    op.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pgcrypto"))
+
+    # =========================================================================
+    # Step 1: Add new UUID columns for all PKs and FKs
+    # =========================================================================
+
+    for table in ALL_TABLES:
+        op.add_column(table, sa.Column("new_id", UUID(as_uuid=True), nullable=True))
+
+    for child_table, fk_col, _parent, _pcol, _nullable, _ondelete in FK_RELATIONSHIPS:
+        op.add_column(child_table, sa.Column(f"new_{fk_col}", UUID(as_uuid=True), nullable=True))
+
+    # =========================================================================
+    # Step 2: Populate new PK UUID columns
+    # =========================================================================
+
+    for table in ALL_TABLES:
+        op.execute(
+            sa.text(f"UPDATE {table} SET new_id = gen_random_uuid() WHERE new_id IS NULL")
+        )
+
+    # =========================================================================
+    # Step 3: Backfill FK UUID columns via JOINs (dependency order)
+    # =========================================================================
+
+    for parent in ("users", "extractor_configs", "extractor_config_versions"):
+        alias = {"users": "u", "extractor_configs": "ec", "extractor_config_versions": "ecv"}[
+            parent
+        ]
+        for child_table, fk_col, parent_table, _pcol, _nullable, _ondelete in FK_RELATIONSHIPS:
+            if parent_table == parent:
+                op.execute(
+                    sa.text(
+                        f"UPDATE {child_table} SET new_{fk_col} = {alias}.new_id "
+                        f"FROM {parent} {alias} "
+                        f"WHERE {child_table}.{fk_col} = {alias}.id"
+                    )
+                )
+
+    # =========================================================================
+    # Step 4: Drop old FK constraints
+    # =========================================================================
+
+    # Actual constraint names from the database (some use fk_ prefix from older migrations)
+    fk_constraints = [
+        ("api_tokens", "api_tokens_user_id_fkey"),
+        ("extractor_configs", "fk_extractor_configs_user_id"),
+        ("extractor_config_versions", "extractor_config_versions_extractor_config_id_fkey"),
+        ("extraction_logs", "fk_extraction_logs_user_id"),
+        ("extraction_logs", "extraction_logs_extractor_config_id_fkey"),
+        ("extraction_logs", "extraction_logs_extractor_config_version_id_fkey"),
+        ("test_extraction_logs", "fk_test_extraction_logs_user_id"),
+        ("test_extraction_logs", "test_extraction_logs_extractor_config_id_fkey"),
+        ("api_call_logs", "fk_api_call_logs_user_id"),
+        ("api_call_logs", "api_call_logs_extractor_config_id_fkey"),
+        ("api_call_logs", "api_call_logs_extractor_config_version_id_fkey"),
+        ("ai_usage_logs", "ai_usage_logs_user_id_fkey"),
+        ("audit_logs", "audit_logs_user_id_fkey"),
+        ("data_consents", "data_consents_user_id_fkey"),
+    ]
+    for table, constraint in fk_constraints:
+        op.drop_constraint(constraint, table, type_="foreignkey")
+
+    # =========================================================================
+    # Step 5: Drop unique constraints that reference old columns
+    # =========================================================================
+
+    op.drop_constraint("uq_extractor_configs_name_user", "extractor_configs", type_="unique")
+
+    # =========================================================================
+    # Step 6: Drop old PK constraints and indexes
+    # =========================================================================
+
+    # Actual PK constraint names (some kept old parser_ prefix from rename migration)
+    pk_constraints = {
+        "users": "users_pkey",
+        "api_tokens": "api_tokens_pkey",
+        "extractor_configs": "parser_configs_pkey",
+        "extractor_config_versions": "parser_config_versions_pkey",
+        "extraction_logs": "extraction_logs_pkey",
+        "test_extraction_logs": "test_extraction_logs_pkey",
+        "api_call_logs": "api_call_logs_pkey",
+        "ai_usage_logs": "ai_usage_logs_pkey",
+        "audit_logs": "audit_logs_pkey",
+        "data_consents": "data_consents_pkey",
+    }
+    for table in ALL_TABLES:
+        op.drop_constraint(pk_constraints[table], table, type_="primary")
+
+    # Actual index names (some kept old parser_ prefix)
+    indexes_to_drop = [
+        ("ix_api_tokens_user_id", "api_tokens"),
+        ("ix_ai_usage_logs_user_id", "ai_usage_logs"),
+        ("ix_audit_logs_user_id", "audit_logs"),
+        ("ix_audit_logs_timestamp", "audit_logs"),
+        ("ix_parser_configs_id", "extractor_configs"),
+        ("ix_parser_config_versions_id", "extractor_config_versions"),
+        ("ix_extraction_logs_id", "extraction_logs"),
+        ("ix_test_extraction_logs_id", "test_extraction_logs"),
+        ("ix_api_call_logs_id", "api_call_logs"),
+    ]
+    for idx_name, table in indexes_to_drop:
+        op.drop_index(idx_name, table_name=table)
+
+    # =========================================================================
+    # Step 7: Drop old integer columns
+    # =========================================================================
+
+    for child_table, fk_col, _parent, _pcol, _nullable, _ondelete in FK_RELATIONSHIPS:
+        op.drop_column(child_table, fk_col)
+
+    for table in ALL_TABLES:
+        op.drop_column(table, "id")
+
+    # =========================================================================
+    # Step 8: Rename new UUID columns to original names
+    # =========================================================================
+
+    for table in ALL_TABLES:
+        op.alter_column(table, "new_id", new_column_name="id", nullable=False)
+
+    for child_table, fk_col, _parent, _pcol, nullable, _ondelete in FK_RELATIONSHIPS:
+        op.alter_column(child_table, f"new_{fk_col}", new_column_name=fk_col, nullable=nullable)
+
+    # =========================================================================
+    # Step 9: Recreate PK constraints
+    # =========================================================================
+
+    for table in ALL_TABLES:
+        op.create_primary_key(f"{table}_pkey", table, ["id"])
+
+    # =========================================================================
+    # Step 10: Recreate FK constraints
+    # =========================================================================
+
+    for child_table, fk_col, parent_table, pcol, _nullable, ondelete in FK_RELATIONSHIPS:
+        kwargs = {}
+        if ondelete:
+            kwargs["ondelete"] = ondelete
+        op.create_foreign_key(
+            f"{child_table}_{fk_col}_fkey",
+            child_table,
+            parent_table,
+            [fk_col],
+            [pcol],
+            **kwargs,
+        )
+
+    # =========================================================================
+    # Step 11: Recreate indexes and unique constraints
+    # =========================================================================
+
+    for idx_name, table in [
+        ("ix_extractor_configs_id", "extractor_configs"),
+        ("ix_extractor_config_versions_id", "extractor_config_versions"),
+        ("ix_extraction_logs_id", "extraction_logs"),
+        ("ix_test_extraction_logs_id", "test_extraction_logs"),
+        ("ix_api_call_logs_id", "api_call_logs"),
+    ]:
+        op.create_index(idx_name, table, ["id"])
+
+    for idx_name, table, col in [
+        ("ix_api_tokens_user_id", "api_tokens", "user_id"),
+        ("ix_ai_usage_logs_user_id", "ai_usage_logs", "user_id"),
+        ("ix_audit_logs_user_id", "audit_logs", "user_id"),
+        ("ix_audit_logs_timestamp", "audit_logs", "timestamp"),
+    ]:
+        op.create_index(idx_name, table, [col])
+
+    op.create_unique_constraint(
+        "uq_extractor_configs_name_user", "extractor_configs", ["name", "user_id"]
+    )
+
+    # =========================================================================
+    # Step 12: Drop leftover sequences from old integer PKs
+    # =========================================================================
+
+    for table in ALL_TABLES:
+        op.execute(sa.text(f"DROP SEQUENCE IF EXISTS {table}_id_seq CASCADE"))
+
+
+def downgrade() -> None:
+    # This migration is irreversible due to data type change from Integer to UUID.
+    pass

--- a/backend/alembic/versions/q7r8s9t0u1v2_migrate_to_uuid_pks.py
+++ b/backend/alembic/versions/q7r8s9t0u1v2_migrate_to_uuid_pks.py
@@ -83,9 +83,7 @@ def upgrade() -> None:
     # =========================================================================
 
     for table in ALL_TABLES:
-        op.execute(
-            sa.text(f"UPDATE {table} SET new_id = gen_random_uuid() WHERE new_id IS NULL")
-        )
+        op.execute(sa.text(f"UPDATE {table} SET new_id = gen_random_uuid() WHERE new_id IS NULL"))
 
     # =========================================================================
     # Step 3: Backfill FK UUID columns via JOINs (dependency order)

--- a/backend/src/domain/entities.py
+++ b/backend/src/domain/entities.py
@@ -1,3 +1,4 @@
+import uuid
 from dataclasses import dataclass, field
 
 
@@ -39,7 +40,7 @@ class SubmissionData:
 
 @dataclass
 class ExtractorConfigData:
-    id: int | None
+    id: uuid.UUID | None
     name: str
     description: str
     prompt: str
@@ -47,15 +48,15 @@ class ExtractorConfigData:
     output_schema: dict
     is_default: bool
     status: str = "active"
-    user_id: int | None = None
+    user_id: uuid.UUID | None = None
     created_at: object | None = None
     updated_at: object | None = None
 
 
 @dataclass
 class ExtractorConfigVersionData:
-    id: int
-    extractor_config_id: int
+    id: uuid.UUID
+    extractor_config_id: uuid.UUID
     version_number: int
     prompt: str
     model: str
@@ -66,7 +67,7 @@ class ExtractorConfigVersionData:
 
 @dataclass
 class UserData:
-    id: int | None
+    id: uuid.UUID | None
     github_id: int | None
     github_username: str
     email: str | None
@@ -77,8 +78,8 @@ class UserData:
 
 @dataclass
 class ApiTokenData:
-    id: int
-    user_id: int
+    id: uuid.UUID
+    user_id: uuid.UUID
     name: str
     created_at: object | None = None
     expires_at: object | None = None

--- a/backend/src/domain/services/api_metrics.py
+++ b/backend/src/domain/services/api_metrics.py
@@ -1,3 +1,5 @@
+import uuid
+
 from src.domain.entities import ApiCallMetricsData
 from src.infrastructure.repository import ApiCallRepository
 
@@ -7,7 +9,7 @@ class ApiMetricsService:
         self.repository = repository
 
     def get_metrics(
-        self, extractor_config_id: int | None = None, user_id: int | None = None
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
     ) -> ApiCallMetricsData:
         total = self.repository.count_total(extractor_config_id, user_id=user_id)
         failures = self.repository.count_failures(extractor_config_id, user_id=user_id)

--- a/backend/src/domain/services/extractor_config.py
+++ b/backend/src/domain/services/extractor_config.py
@@ -44,9 +44,7 @@ class ExtractorConfigService:
             self._clear_default()
         return self.repository.create(data, user_id=user_id)
 
-    def update(
-        self, config_id: uuid.UUID, data: ExtractorConfigData
-    ) -> ExtractorConfigData | None:
+    def update(self, config_id: uuid.UUID, data: ExtractorConfigData) -> ExtractorConfigData | None:
         if data.status == "draft":
             data.is_default = False
         if data.is_default:

--- a/backend/src/domain/services/extractor_config.py
+++ b/backend/src/domain/services/extractor_config.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Protocol
 
 from src.domain.entities import ExtractorConfigData, ExtractorConfigVersionData
@@ -5,16 +6,18 @@ from src.domain.entities import ExtractorConfigData, ExtractorConfigVersionData
 
 class ExtractorConfigRepo(Protocol):
     def get_all(
-        self, status: str | None = None, user_id: int | None = None
+        self, status: str | None = None, user_id: uuid.UUID | None = None
     ) -> list[ExtractorConfigData]: ...
-    def get_by_id(self, config_id: int) -> ExtractorConfigData | None: ...
+    def get_by_id(self, config_id: uuid.UUID) -> ExtractorConfigData | None: ...
     def get_default(self) -> ExtractorConfigData | None: ...
     def create(
-        self, data: ExtractorConfigData, user_id: int | None = None
+        self, data: ExtractorConfigData, user_id: uuid.UUID | None = None
     ) -> ExtractorConfigData: ...
-    def update(self, config_id: int, data: ExtractorConfigData) -> ExtractorConfigData | None: ...
-    def delete(self, config_id: int) -> bool: ...
-    def get_versions(self, config_id: int) -> list[ExtractorConfigVersionData]: ...
+    def update(
+        self, config_id: uuid.UUID, data: ExtractorConfigData
+    ) -> ExtractorConfigData | None: ...
+    def delete(self, config_id: uuid.UUID) -> bool: ...
+    def get_versions(self, config_id: uuid.UUID) -> list[ExtractorConfigVersionData]: ...
 
 
 class ExtractorConfigService:
@@ -22,37 +25,41 @@ class ExtractorConfigService:
         self.repository = repository
 
     def get_all(
-        self, status: str | None = None, user_id: int | None = None
+        self, status: str | None = None, user_id: uuid.UUID | None = None
     ) -> list[ExtractorConfigData]:
         return self.repository.get_all(status=status, user_id=user_id)
 
-    def get_by_id(self, config_id: int) -> ExtractorConfigData | None:
+    def get_by_id(self, config_id: uuid.UUID) -> ExtractorConfigData | None:
         return self.repository.get_by_id(config_id)
 
     def get_default(self) -> ExtractorConfigData | None:
         return self.repository.get_default()
 
-    def create(self, data: ExtractorConfigData, user_id: int | None = None) -> ExtractorConfigData:
+    def create(
+        self, data: ExtractorConfigData, user_id: uuid.UUID | None = None
+    ) -> ExtractorConfigData:
         if data.status == "draft":
             data.is_default = False
         if data.is_default:
             self._clear_default()
         return self.repository.create(data, user_id=user_id)
 
-    def update(self, config_id: int, data: ExtractorConfigData) -> ExtractorConfigData | None:
+    def update(
+        self, config_id: uuid.UUID, data: ExtractorConfigData
+    ) -> ExtractorConfigData | None:
         if data.status == "draft":
             data.is_default = False
         if data.is_default:
             self._clear_default(exclude_id=config_id)
         return self.repository.update(config_id, data)
 
-    def delete(self, config_id: int) -> bool:
+    def delete(self, config_id: uuid.UUID) -> bool:
         return self.repository.delete(config_id)
 
-    def get_versions(self, config_id: int) -> list[ExtractorConfigVersionData]:
+    def get_versions(self, config_id: uuid.UUID) -> list[ExtractorConfigVersionData]:
         return self.repository.get_versions(config_id)
 
-    def _clear_default(self, exclude_id: int | None = None) -> None:
+    def _clear_default(self, exclude_id: uuid.UUID | None = None) -> None:
         for config in self.repository.get_all():
             if config.is_default and config.id != exclude_id:
                 config.is_default = False

--- a/backend/src/domain/services/metrics.py
+++ b/backend/src/domain/services/metrics.py
@@ -1,3 +1,5 @@
+import uuid
+
 from src.domain.entities import MetricsData
 from src.infrastructure.repository import ExtractionRepository
 
@@ -7,7 +9,7 @@ class MetricsService:
         self.repository = repository
 
     def get_metrics(
-        self, extractor_config_id: int | None = None, user_id: int | None = None
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
     ) -> MetricsData:
         any_corrected, field_corrections, total = self.repository.count_corrections(
             extractor_config_id, user_id=user_id

--- a/backend/src/domain/services/submission.py
+++ b/backend/src/domain/services/submission.py
@@ -1,3 +1,5 @@
+import uuid
+
 from src.domain.entities import SubmissionData
 from src.infrastructure.models import ExtractionLog
 from src.infrastructure.repository import ExtractionRepository
@@ -10,10 +12,10 @@ class SubmissionService:
     def submit_extraction(
         self,
         submission: SubmissionData,
-        extractor_config_id: int | None = None,
-        extractor_config_version_id: int | None = None,
-        user_id: int | None = None,
-    ) -> int:
+        extractor_config_id: uuid.UUID | None = None,
+        extractor_config_version_id: uuid.UUID | None = None,
+        user_id: uuid.UUID | None = None,
+    ) -> uuid.UUID:
         log_entry = ExtractionLog(
             filename=submission.filename,
             extracted_fields=submission.extracted_fields,
@@ -24,14 +26,14 @@ class SubmissionService:
         )
 
         created_log = self.repository.create(log_entry)
-        return int(created_log.id)  # type: ignore[arg-type]
+        return created_log.id  # type: ignore[return-value]
 
     def get_extraction_logs(
         self,
         page: int,
         page_size: int,
-        extractor_config_id: int | None = None,
-        user_id: int | None = None,
+        extractor_config_id: uuid.UUID | None = None,
+        user_id: uuid.UUID | None = None,
     ) -> tuple[list[ExtractionLog], int, int]:
         if page < 1:
             raise ValueError("Page must be >= 1")

--- a/backend/src/infrastructure/api/admin/routes.py
+++ b/backend/src/infrastructure/api/admin/routes.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -24,7 +25,7 @@ class UpdateUserRequest(BaseModel):
 
 
 class UserResponse(BaseModel):
-    id: int
+    id: uuid.UUID
     github_id: int | None
     github_username: str
     email: str | None
@@ -72,7 +73,7 @@ async def create_user(request: CreateUserRequest, admin: AdminDep, db: DbDep):
 
 
 @router.put("/users/{user_id}", response_model=UserResponse)
-async def update_user(user_id: int, request: UpdateUserRequest, admin: AdminDep, db: DbDep):
+async def update_user(user_id: uuid.UUID, request: UpdateUserRequest, admin: AdminDep, db: DbDep):
     repo = UserRepository(db)
     fields = {}
     if request.role is not None:
@@ -98,7 +99,7 @@ async def update_user(user_id: int, request: UpdateUserRequest, admin: AdminDep,
 
 
 @router.delete("/users/{user_id}")
-async def delete_user(user_id: int, admin: AdminDep, db: DbDep):
+async def delete_user(user_id: uuid.UUID, admin: AdminDep, db: DbDep):
     if admin.id == user_id:
         raise HTTPException(status_code=400, detail="No puedes eliminarte a ti mismo")
     repo = UserRepository(db)

--- a/backend/src/infrastructure/api/auth/routes.py
+++ b/backend/src/infrastructure/api/auth/routes.py
@@ -1,3 +1,4 @@
+import uuid
 from dataclasses import replace
 from typing import Annotated
 
@@ -22,7 +23,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 DbDep = Annotated[Session, Depends(get_db)]
 
 
-def _create_default_extractor(db: Session, user_id: int) -> None:
+def _create_default_extractor(db: Session, user_id: uuid.UUID) -> None:
     """Crea el extractor default de boletas para un usuario nuevo."""
     repo = ExtractorConfigRepository(db)
     existing = repo.get_all(user_id=user_id)
@@ -43,7 +44,7 @@ class LoginResponse(BaseModel):
 
 
 class UserResponse(BaseModel):
-    id: int
+    id: uuid.UUID
     github_username: str
     email: str | None
     avatar_url: str | None

--- a/backend/src/infrastructure/api/extraction/dtos.py
+++ b/backend/src/infrastructure/api/extraction/dtos.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 from typing import Any
 
@@ -6,9 +7,9 @@ from pydantic import BaseModel, ConfigDict, field_validator
 
 class ExtractionResponse(BaseModel):
     fields: dict[str, Any] = {}
-    extractor_config_id: int | None = None
+    extractor_config_id: uuid.UUID | None = None
     extractor_config_name: str = ""
-    extractor_config_version_id: int | None = None
+    extractor_config_version_id: uuid.UUID | None = None
     extractor_config_version_number: int | None = None
 
 
@@ -16,13 +17,13 @@ class SubmissionRequest(BaseModel):
     filename: str
     extracted_fields: dict[str, str]
     final_fields: dict[str, str]
-    extractor_config_id: int | None = None
-    extractor_config_version_id: int | None = None
+    extractor_config_id: uuid.UUID | None = None
+    extractor_config_version_id: uuid.UUID | None = None
 
 
 class SubmissionResponse(BaseModel):
     message: str
-    id: int
+    id: uuid.UUID
 
 
 class Bank(BaseModel):
@@ -37,13 +38,13 @@ class BanksResponse(BaseModel):
 class ExtractionLogResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: int
+    id: uuid.UUID
     timestamp: str | None
     filename: str
     extracted_fields: dict[str, Any] = {}
     final_fields: dict[str, Any] = {}
     corrected_fields: dict[str, bool] = {}
-    extractor_config_version_id: int | None = None
+    extractor_config_version_id: uuid.UUID | None = None
     extractor_config_name: str | None = None
 
     @field_validator("timestamp", mode="before")
@@ -147,7 +148,7 @@ class ExtractorConfigUpdateRequest(BaseModel):
 class ExtractorConfigResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: int
+    id: uuid.UUID
     name: str
     description: str | None
     prompt: str
@@ -173,7 +174,7 @@ class ExtractorConfigListResponse(BaseModel):
 class ExtractorConfigVersionResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: int
+    id: uuid.UUID
     version_number: int
     prompt: str
     model: str
@@ -223,7 +224,7 @@ class UpdatePromptRequest(BaseModel):
 class TestExtractResponse(BaseModel):
     fields: dict[str, Any]
     response_time_ms: float
-    test_log_id: int | None = None
+    test_log_id: uuid.UUID | None = None
 
 
 class SetActiveRequest(BaseModel):
@@ -244,17 +245,17 @@ class UploadUrlResponse(BaseModel):
 class ExtractRequest(BaseModel):
     s3_key: str
     filename: str
-    extractor_config_id: int | None = None
+    extractor_config_id: uuid.UUID | None = None
 
 
 class TestExtractionLogResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: int
+    id: uuid.UUID
     timestamp: str | None
     filename: str
     s3_key: str
-    extractor_config_id: int | None
+    extractor_config_id: uuid.UUID | None
     prompt_snapshot: str
     model: str
     output_schema_snapshot: dict[str, Any]
@@ -275,4 +276,4 @@ class TestExtractRequest(BaseModel):
     s3_key: str
     filename: str
     config: dict[str, Any]
-    extractor_config_id: int | None = None
+    extractor_config_id: uuid.UUID | None = None

--- a/backend/src/infrastructure/api/extraction/routes.py
+++ b/backend/src/infrastructure/api/extraction/routes.py
@@ -1,4 +1,5 @@
 import random
+import uuid
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
@@ -51,7 +52,7 @@ def _get_repository(db: Session) -> ExtractionRepository:
     return ExtractionRepository(db)
 
 
-def _load_config(db: Session, config_id: int | None) -> ExtractorConfigData | None:
+def _load_config(db: Session, config_id: uuid.UUID | None) -> ExtractorConfigData | None:
     if config_id is None:
         return None
     repo = ExtractorConfigRepository(db)
@@ -63,7 +64,7 @@ def _load_config(db: Session, config_id: int | None) -> ExtractorConfigData | No
 
 def _select_variant(
     config: ExtractorConfigData, active_versions: list[ExtractorConfigVersionData]
-) -> tuple[ExtractorConfigData, int | None, int | None]:
+) -> tuple[ExtractorConfigData, uuid.UUID | None, int | None]:
     """Pick a variant randomly from current config + active versions.
 
     Returns (config_to_use, version_id, version_number).
@@ -221,7 +222,7 @@ async def get_extraction_logs(
     user: UserDep,
     page: int = 1,
     page_size: int = 50,
-    extractor_config_id: int | None = None,
+    extractor_config_id: uuid.UUID | None = None,
 ):
     try:
         user_filter = None if user.role == "admin" else user.id
@@ -232,7 +233,7 @@ async def get_extraction_logs(
 
         config_repo = ExtractorConfigRepository(db)
         config_ids = {log.extractor_config_id for log in logs if log.extractor_config_id}
-        config_names: dict[int, str] = {}
+        config_names: dict[uuid.UUID, str] = {}
         for cid in config_ids:
             cfg = config_repo.get_by_id(cid)
             if cfg:
@@ -260,7 +261,7 @@ async def get_extraction_logs(
 
 
 @router.get("/metrics", response_model=MetricsResponse)
-async def get_metrics(db: DbDep, user: UserDep, extractor_config_id: int | None = None):
+async def get_metrics(db: DbDep, user: UserDep, extractor_config_id: uuid.UUID | None = None):
     try:
         user_filter = None if user.role == "admin" else user.id
         service = MetricsService(_get_repository(db))
@@ -272,7 +273,7 @@ async def get_metrics(db: DbDep, user: UserDep, extractor_config_id: int | None 
 
 
 @router.get("/api-metrics", response_model=ApiCallMetricsResponse)
-async def get_api_metrics(db: DbDep, user: UserDep, extractor_config_id: int | None = None):
+async def get_api_metrics(db: DbDep, user: UserDep, extractor_config_id: uuid.UUID | None = None):
     try:
         user_filter = None if user.role == "admin" else user.id
         service = ApiMetricsService(ApiCallRepository(db))

--- a/backend/src/infrastructure/api/extractors/routes.py
+++ b/backend/src/infrastructure/api/extractors/routes.py
@@ -1,5 +1,6 @@
 import tempfile
 import time
+import uuid
 from pathlib import Path
 from typing import Annotated
 
@@ -239,7 +240,7 @@ async def test_extract(request: TestExtractRequest, db: DbDep, user: UserDep):
 
 
 @router.get("/{config_id}/test-logs", response_model=list[TestExtractionLogResponse])
-async def get_test_logs(config_id: int, db: DbDep, user: UserDep):
+async def get_test_logs(config_id: uuid.UUID, db: DbDep, user: UserDep):
     service = _get_service(db)
     config = service.get_by_id(config_id)
     if not config:
@@ -251,7 +252,7 @@ async def get_test_logs(config_id: int, db: DbDep, user: UserDep):
 
 
 @router.get("/{config_id}", response_model=ExtractorConfigResponse)
-async def get_extractor_config(config_id: int, db: DbDep, user: UserDep):
+async def get_extractor_config(config_id: uuid.UUID, db: DbDep, user: UserDep):
     service = _get_service(db)
     config = service.get_by_id(config_id)
     if not config:
@@ -261,7 +262,7 @@ async def get_extractor_config(config_id: int, db: DbDep, user: UserDep):
 
 
 @router.get("/{config_id}/versions", response_model=list[ExtractorConfigVersionResponse])
-async def get_extractor_versions(config_id: int, db: DbDep, user: UserDep):
+async def get_extractor_versions(config_id: uuid.UUID, db: DbDep, user: UserDep):
     service = _get_service(db)
     config = service.get_by_id(config_id)
     if not config:
@@ -292,7 +293,7 @@ async def create_extractor_config(request: ExtractorConfigCreateRequest, db: DbD
 
 @router.put("/{config_id}", response_model=ExtractorConfigResponse)
 async def update_extractor_config(
-    config_id: int, request: ExtractorConfigUpdateRequest, db: DbDep, user: UserDep
+    config_id: uuid.UUID, request: ExtractorConfigUpdateRequest, db: DbDep, user: UserDep
 ):
     service = _get_service(db)
     existing = service.get_by_id(config_id)
@@ -319,7 +320,7 @@ async def update_extractor_config(
 
 
 @router.delete("/{config_id}")
-async def delete_extractor_config(config_id: int, db: DbDep, user: UserDep):
+async def delete_extractor_config(config_id: uuid.UUID, db: DbDep, user: UserDep):
     service = _get_service(db)
     existing = service.get_by_id(config_id)
     if not existing:
@@ -338,7 +339,7 @@ async def delete_extractor_config(config_id: int, db: DbDep, user: UserDep):
     response_model=ExtractorConfigVersionResponse,
 )
 async def toggle_version_active(
-    config_id: int, version_id: int, request: SetActiveRequest, db: DbDep, user: UserDep
+    config_id: uuid.UUID, version_id: uuid.UUID, request: SetActiveRequest, db: DbDep, user: UserDep
 ):
     repo = ExtractorConfigRepository(db)
     config = repo.get_by_id(config_id)

--- a/backend/src/infrastructure/api/tokens/routes.py
+++ b/backend/src/infrastructure/api/tokens/routes.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -17,7 +18,7 @@ class CreateTokenRequest(BaseModel):
 
 
 class TokenResponse(BaseModel):
-    id: int
+    id: uuid.UUID
     name: str
     created_at: datetime | None
     expires_at: datetime | None
@@ -27,7 +28,7 @@ class TokenResponse(BaseModel):
 
 class CreateTokenResponse(BaseModel):
     token: str
-    id: int
+    id: uuid.UUID
     name: str
     expires_at: datetime | None
 
@@ -82,7 +83,7 @@ def list_tokens(
 
 @router.delete("/{token_id}")
 def revoke_token(
-    token_id: int,
+    token_id: uuid.UUID,
     user: UserDep,
     db: Session = Depends(get_db),
 ):

--- a/backend/src/infrastructure/auth.py
+++ b/backend/src/infrastructure/auth.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import secrets
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
@@ -22,7 +23,7 @@ TOKEN_PREFIX = "exto_"
 
 def create_access_token(user: UserData) -> str:
     payload = {
-        "user_id": user.id,
+        "user_id": str(user.id),
         "role": user.role,
         "exp": datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRY_HOURS),
         "iat": datetime.now(timezone.utc),
@@ -62,8 +63,13 @@ def _authenticate_jwt(token: str, db: Session) -> UserData:
     except jwt.InvalidTokenError:
         raise HTTPException(status_code=401, detail="Token inválido")
 
-    user_id = payload.get("user_id")
-    if not user_id:
+    raw_user_id = payload.get("user_id")
+    if not raw_user_id:
+        raise HTTPException(status_code=401, detail="Token inválido")
+
+    try:
+        user_id = uuid.UUID(raw_user_id)
+    except (ValueError, AttributeError):
         raise HTTPException(status_code=401, detail="Token inválido")
 
     repo = UserRepository(db)

--- a/backend/src/infrastructure/database.py
+++ b/backend/src/infrastructure/database.py
@@ -1,6 +1,5 @@
 import os
 from collections.abc import Generator
-from pathlib import Path
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -16,19 +15,13 @@ def get_database_url() -> str:
             url = url.replace("postgres://", "postgresql://", 1)
         return url
 
-    # Default: SQLite for local dev without Docker
-    db_dir = Path(__file__).parent.parent.parent / "data"
-    db_dir.mkdir(exist_ok=True)
-    return f"sqlite:///{db_dir / 'extractions.db'}"
+    # Default: local Docker PostgreSQL
+    return "postgresql://postgres:postgres@localhost:5432/extractions"
 
 
 database_url = get_database_url()
 
-connect_args = {}
-if database_url.startswith("sqlite"):
-    connect_args["check_same_thread"] = False
-
-engine = create_engine(database_url, connect_args=connect_args)
+engine = create_engine(database_url)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 

--- a/backend/src/infrastructure/models.py
+++ b/backend/src/infrastructure/models.py
@@ -185,9 +185,7 @@ class DataConsent(Base):
     __tablename__ = "data_consents"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id = Column(
-        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     consent_type = Column(String(100), nullable=False)
     granted = Column(Boolean, nullable=False, default=True)
     granted_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/backend/src/infrastructure/models.py
+++ b/backend/src/infrastructure/models.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy import (
@@ -11,7 +12,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.ext.declarative import declarative_base
 
 from src.infrastructure.encryption import EncryptedJSON
@@ -22,7 +23,7 @@ Base = declarative_base()
 class User(Base):
     __tablename__ = "users"
 
-    id = Column(Integer, primary_key=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     github_id = Column(Integer, unique=True, nullable=True, index=True)
     github_username = Column(String(100), unique=True, nullable=False)
     email = Column(String(255), nullable=True)
@@ -36,9 +37,9 @@ class User(Base):
 class ApiToken(Base):
     __tablename__ = "api_tokens"
 
-    id = Column(Integer, primary_key=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     user_id = Column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     name = Column(String(200), nullable=False)
     token_hash = Column(String(64), unique=True, nullable=False, index=True)
@@ -52,14 +53,14 @@ class ExtractorConfig(Base):
     __tablename__ = "extractor_configs"
     __table_args__ = (UniqueConstraint("name", "user_id", name="uq_extractor_configs_name_user"),)
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     name = Column(String(200), nullable=False)
     description = Column(String(500), nullable=True)
     prompt = Column(Text, nullable=False)
     model = Column(String(100), nullable=False, default="claude-haiku-4-5-20251001")
     output_schema = Column(JSON, nullable=False)
     is_default = Column(Boolean, default=False)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     status = Column(String(20), nullable=False, default="active")
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(
@@ -72,8 +73,10 @@ class ExtractorConfig(Base):
 class ExtractorConfigVersion(Base):
     __tablename__ = "extractor_config_versions"
 
-    id = Column(Integer, primary_key=True, index=True)
-    extractor_config_id = Column(Integer, ForeignKey("extractor_configs.id"), nullable=False)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+    extractor_config_id = Column(
+        UUID(as_uuid=True), ForeignKey("extractor_configs.id"), nullable=False
+    )
     version_number = Column(Integer, nullable=False)
     prompt = Column(Text, nullable=False)
     model = Column(String(100), nullable=False)
@@ -85,17 +88,19 @@ class ExtractorConfigVersion(Base):
 class ExtractionLog(Base):
     __tablename__ = "extraction_logs"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
     filename = Column(String, nullable=False)
 
     extracted_fields = Column(EncryptedJSON, default=dict)
     final_fields = Column(EncryptedJSON, default=dict)
 
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
-    extractor_config_id = Column(Integer, ForeignKey("extractor_configs.id"), nullable=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    extractor_config_id = Column(
+        UUID(as_uuid=True), ForeignKey("extractor_configs.id"), nullable=True
+    )
     extractor_config_version_id = Column(
-        Integer, ForeignKey("extractor_config_versions.id"), nullable=True
+        UUID(as_uuid=True), ForeignKey("extractor_config_versions.id"), nullable=True
     )
 
     @property
@@ -113,13 +118,13 @@ class ExtractionLog(Base):
 class TestExtractionLog(Base):
     __tablename__ = "test_extraction_logs"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
     filename = Column(String, nullable=False)
     s3_key = Column(String, nullable=False)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     extractor_config_id = Column(
-        Integer, ForeignKey("extractor_configs.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), ForeignKey("extractor_configs.id", ondelete="SET NULL"), nullable=True
     )
     prompt_snapshot = Column(Text, nullable=False)
     model = Column(String(100), nullable=False)
@@ -133,26 +138,28 @@ class TestExtractionLog(Base):
 class ApiCallLog(Base):
     __tablename__ = "api_call_logs"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     model = Column(String, nullable=False)
     success = Column(Boolean, nullable=False)
     error_type = Column(String, nullable=True)
     error_message = Column(String, nullable=True)
     response_time_ms = Column(Float, nullable=False)
     filename = Column(String, nullable=True)
-    extractor_config_id = Column(Integer, ForeignKey("extractor_configs.id"), nullable=True)
+    extractor_config_id = Column(
+        UUID(as_uuid=True), ForeignKey("extractor_configs.id"), nullable=True
+    )
     extractor_config_version_id = Column(
-        Integer, ForeignKey("extractor_config_versions.id"), nullable=True
+        UUID(as_uuid=True), ForeignKey("extractor_config_versions.id"), nullable=True
     )
 
 
 class AiUsageLog(Base):
     __tablename__ = "ai_usage_logs"
 
-    id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)
     action = Column(String(50), nullable=False)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
@@ -162,8 +169,8 @@ class AuditLog(Base):
 
     __tablename__ = "audit_logs"
 
-    id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True)
     action = Column(String(100), nullable=False)
     resource_type = Column(String(50), nullable=False)
     resource_id = Column(String(50), nullable=True)
@@ -177,8 +184,10 @@ class DataConsent(Base):
 
     __tablename__ = "data_consents"
 
-    id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
     consent_type = Column(String(100), nullable=False)
     granted = Column(Boolean, nullable=False, default=True)
     granted_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/backend/src/infrastructure/repository.py
+++ b/backend/src/infrastructure/repository.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func
@@ -28,7 +29,9 @@ class ExtractionRepository:
     def __init__(self, session: Session):
         self.session = session
 
-    def _base_query(self, extractor_config_id: int | None = None, user_id: int | None = None):
+    def _base_query(
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
+    ):
         q = self.session.query(ExtractionLog)
         if user_id is not None:
             q = q.filter(ExtractionLog.user_id == user_id)
@@ -40,8 +43,8 @@ class ExtractionRepository:
         self,
         page: int,
         page_size: int,
-        extractor_config_id: int | None = None,
-        user_id: int | None = None,
+        extractor_config_id: uuid.UUID | None = None,
+        user_id: uuid.UUID | None = None,
     ) -> tuple[list[ExtractionLog], int]:
         q = self._base_query(extractor_config_id, user_id=user_id)
         total = q.count()
@@ -49,7 +52,7 @@ class ExtractionRepository:
         logs = q.order_by(ExtractionLog.timestamp.desc()).offset(offset).limit(page_size).all()
         return logs, total
 
-    def get_by_id(self, log_id: int) -> ExtractionLog | None:
+    def get_by_id(self, log_id: uuid.UUID) -> ExtractionLog | None:
         return self.session.query(ExtractionLog).filter(ExtractionLog.id == log_id).first()
 
     def create(self, log_entry: ExtractionLog) -> ExtractionLog:
@@ -59,7 +62,7 @@ class ExtractionRepository:
         return log_entry
 
     def count_total(
-        self, extractor_config_id: int | None = None, user_id: int | None = None
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
     ) -> int:
         q = self.session.query(func.count(ExtractionLog.id))
         if user_id is not None:
@@ -69,7 +72,7 @@ class ExtractionRepository:
         return q.scalar() or 0
 
     def count_corrections(
-        self, extractor_config_id: int | None = None, user_id: int | None = None
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
     ) -> tuple[int, dict[str, int], int]:
         """Returns (any_corrected_count, {field: correction_count}, total)."""
         q = self._base_query(extractor_config_id, user_id=user_id)
@@ -90,7 +93,7 @@ class ExtractionRepository:
         return any_corrected, field_corrections, total
 
     def count_this_week(
-        self, extractor_config_id: int | None = None, user_id: int | None = None
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
     ) -> int:
         week_ago = datetime.now(timezone.utc) - timedelta(days=7)
         q = self.session.query(func.count(ExtractionLog.id)).filter(
@@ -102,7 +105,7 @@ class ExtractionRepository:
             q = q.filter(ExtractionLog.extractor_config_id == extractor_config_id)
         return q.scalar() or 0
 
-    def count_today(self, user_id: int) -> int:
+    def count_today(self, user_id: uuid.UUID) -> int:
         today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
         return (
             self.session.query(func.count(ExtractionLog.id))
@@ -146,7 +149,7 @@ class ExtractorConfigRepository:
         )
 
     def get_all(
-        self, status: str | None = None, user_id: int | None = None
+        self, status: str | None = None, user_id: uuid.UUID | None = None
     ) -> list[ExtractorConfigData]:
         q = self.session.query(ExtractorConfig)
         if user_id is not None:
@@ -156,7 +159,7 @@ class ExtractorConfigRepository:
         configs = q.order_by(ExtractorConfig.id).all()
         return [self._to_entity(c) for c in configs]
 
-    def count_by_user(self, user_id: int) -> int:
+    def count_by_user(self, user_id: uuid.UUID) -> int:
         return (
             self.session.query(func.count(ExtractorConfig.id))
             .filter(
@@ -167,10 +170,10 @@ class ExtractorConfigRepository:
             or 0
         )
 
-    def _get_orm_by_id(self, config_id: int) -> ExtractorConfig | None:
+    def _get_orm_by_id(self, config_id: uuid.UUID) -> ExtractorConfig | None:
         return self.session.query(ExtractorConfig).filter(ExtractorConfig.id == config_id).first()
 
-    def get_by_id(self, config_id: int) -> ExtractorConfigData | None:
+    def get_by_id(self, config_id: uuid.UUID) -> ExtractorConfigData | None:
         config = self._get_orm_by_id(config_id)
         return self._to_entity(config) if config else None
 
@@ -180,7 +183,9 @@ class ExtractorConfigRepository:
         )
         return self._to_entity(config) if config else None
 
-    def create(self, data: ExtractorConfigData, user_id: int | None = None) -> ExtractorConfigData:
+    def create(
+        self, data: ExtractorConfigData, user_id: uuid.UUID | None = None
+    ) -> ExtractorConfigData:
         config = ExtractorConfig(
             name=data.name,
             description=data.description,
@@ -196,7 +201,7 @@ class ExtractorConfigRepository:
         self.session.refresh(config)
         return self._to_entity(config)
 
-    def update(self, config_id: int, data: ExtractorConfigData) -> ExtractorConfigData | None:
+    def update(self, config_id: uuid.UUID, data: ExtractorConfigData) -> ExtractorConfigData | None:
         config = self._get_orm_by_id(config_id)
         if not config:
             return None
@@ -231,7 +236,7 @@ class ExtractorConfigRepository:
 
         return self._to_entity(config)
 
-    def delete(self, config_id: int) -> bool:
+    def delete(self, config_id: uuid.UUID) -> bool:
         config = self._get_orm_by_id(config_id)
         if not config:
             return False
@@ -240,7 +245,7 @@ class ExtractorConfigRepository:
         self.session.commit()
         return True
 
-    def get_versions(self, config_id: int) -> list[ExtractorConfigVersionData]:
+    def get_versions(self, config_id: uuid.UUID) -> list[ExtractorConfigVersionData]:
         versions = (
             self.session.query(ExtractorConfigVersion)
             .filter(ExtractorConfigVersion.extractor_config_id == config_id)
@@ -249,11 +254,11 @@ class ExtractorConfigRepository:
         )
         return [self._version_to_entity(v) for v in versions]
 
-    def get_active_versions(self, config_id: int) -> list[ExtractorConfigVersionData]:
+    def get_active_versions(self, config_id: uuid.UUID) -> list[ExtractorConfigVersionData]:
         versions = self._get_active_versions_orm(config_id)
         return [self._version_to_entity(v) for v in versions]
 
-    def _get_active_versions_orm(self, config_id: int) -> list[ExtractorConfigVersion]:
+    def _get_active_versions_orm(self, config_id: uuid.UUID) -> list[ExtractorConfigVersion]:
         return (
             self.session.query(ExtractorConfigVersion)
             .filter(
@@ -264,7 +269,7 @@ class ExtractorConfigRepository:
         )
 
     def set_version_active(
-        self, version_id: int, active: bool
+        self, version_id: uuid.UUID, active: bool
     ) -> ExtractorConfigVersionData | None:
         version = (
             self.session.query(ExtractorConfigVersion)
@@ -278,7 +283,7 @@ class ExtractorConfigRepository:
         self.session.refresh(version)
         return self._version_to_entity(version)
 
-    def _deactivate_incompatible_versions(self, config_id: int, schema: dict) -> None:
+    def _deactivate_incompatible_versions(self, config_id: uuid.UUID, schema: dict) -> None:
         current_keys = sorted(schema.get("properties", {}).keys())
         active_versions = self._get_active_versions_orm(config_id)
         for version in active_versions:
@@ -296,9 +301,9 @@ class ApiCallRepository:
         self,
         call_result: ApiCallResult,
         filename: str | None = None,
-        extractor_config_id: int | None = None,
-        extractor_config_version_id: int | None = None,
-        user_id: int | None = None,
+        extractor_config_id: uuid.UUID | None = None,
+        extractor_config_version_id: uuid.UUID | None = None,
+        user_id: uuid.UUID | None = None,
     ) -> ApiCallLog:
         log = ApiCallLog(
             model=call_result.model,
@@ -316,7 +321,7 @@ class ApiCallRepository:
         self.session.refresh(log)
         return log
 
-    def _filtered(self, q, extractor_config_id: int | None, user_id: int | None):
+    def _filtered(self, q, extractor_config_id: uuid.UUID | None, user_id: uuid.UUID | None):
         if user_id is not None:
             q = q.filter(ApiCallLog.user_id == user_id)
         if extractor_config_id is not None:
@@ -324,19 +329,19 @@ class ApiCallRepository:
         return q
 
     def count_total(
-        self, extractor_config_id: int | None = None, user_id: int | None = None
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
     ) -> int:
         q = self.session.query(func.count(ApiCallLog.id))
         return self._filtered(q, extractor_config_id, user_id).scalar() or 0
 
     def count_failures(
-        self, extractor_config_id: int | None = None, user_id: int | None = None
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
     ) -> int:
         q = self.session.query(func.count(ApiCallLog.id)).filter(ApiCallLog.success.is_(False))
         return self._filtered(q, extractor_config_id, user_id).scalar() or 0
 
     def count_by_error_type(
-        self, extractor_config_id: int | None = None, user_id: int | None = None
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
     ) -> list[tuple[str, int]]:
         q = self.session.query(ApiCallLog.error_type, func.count(ApiCallLog.id)).filter(
             ApiCallLog.error_type.isnot(None)
@@ -344,20 +349,20 @@ class ApiCallRepository:
         return self._filtered(q, extractor_config_id, user_id).group_by(ApiCallLog.error_type).all()
 
     def avg_response_time_ms(
-        self, extractor_config_id: int | None = None, user_id: int | None = None
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
     ) -> float:
         q = self.session.query(func.avg(ApiCallLog.response_time_ms))
         result = self._filtered(q, extractor_config_id, user_id).scalar()
         return round(result, 1) if result else 0.0
 
     def count_this_week(
-        self, extractor_config_id: int | None = None, user_id: int | None = None
+        self, extractor_config_id: uuid.UUID | None = None, user_id: uuid.UUID | None = None
     ) -> int:
         week_ago = datetime.now(timezone.utc) - timedelta(days=7)
         q = self.session.query(func.count(ApiCallLog.id)).filter(ApiCallLog.timestamp >= week_ago)
         return self._filtered(q, extractor_config_id, user_id).scalar() or 0
 
-    def count_today(self, user_id: int) -> int:
+    def count_today(self, user_id: uuid.UUID) -> int:
         today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
         return (
             self.session.query(func.count(ApiCallLog.id))
@@ -382,8 +387,8 @@ class TestExtractionLogRepository:
         success: bool,
         response_time_ms: float,
         error_message: str | None = None,
-        extractor_config_id: int | None = None,
-        user_id: int | None = None,
+        extractor_config_id: uuid.UUID | None = None,
+        user_id: uuid.UUID | None = None,
     ) -> TestExtractionLog:
         log = TestExtractionLog(
             filename=filename,
@@ -403,7 +408,7 @@ class TestExtractionLogRepository:
         self.session.refresh(log)
         return log
 
-    def get_by_config_id(self, config_id: int) -> list[TestExtractionLog]:
+    def get_by_config_id(self, config_id: uuid.UUID) -> list[TestExtractionLog]:
         return (
             self.session.query(TestExtractionLog)
             .filter(TestExtractionLog.extractor_config_id == config_id)
@@ -429,7 +434,7 @@ class ApiTokenRepository:
         )
 
     def create(
-        self, user_id: int, name: str, token_hash: str, expires_at: datetime | None = None
+        self, user_id: uuid.UUID, name: str, token_hash: str, expires_at: datetime | None = None
     ) -> ApiTokenData:
         token = ApiToken(
             user_id=user_id,
@@ -446,7 +451,7 @@ class ApiTokenRepository:
         token = self.session.query(ApiToken).filter(ApiToken.token_hash == token_hash).first()
         return self._to_entity(token) if token else None
 
-    def get_by_user(self, user_id: int) -> list[ApiTokenData]:
+    def get_by_user(self, user_id: uuid.UUID) -> list[ApiTokenData]:
         tokens = (
             self.session.query(ApiToken)
             .filter(ApiToken.user_id == user_id)
@@ -455,7 +460,7 @@ class ApiTokenRepository:
         )
         return [self._to_entity(t) for t in tokens]
 
-    def revoke(self, token_id: int, user_id: int) -> bool:
+    def revoke(self, token_id: uuid.UUID, user_id: uuid.UUID) -> bool:
         token = (
             self.session.query(ApiToken)
             .filter(ApiToken.id == token_id, ApiToken.user_id == user_id)
@@ -498,7 +503,7 @@ class UserRepository:
         user = self.session.query(User).filter(User.github_username == username).first()
         return self._to_entity(user) if user else None
 
-    def get_by_id(self, user_id: int) -> UserData | None:
+    def get_by_id(self, user_id: uuid.UUID) -> UserData | None:
         user = self.session.query(User).filter(User.id == user_id).first()
         return self._to_entity(user) if user else None
 
@@ -513,7 +518,7 @@ class UserRepository:
         self.session.refresh(user)
         return self._to_entity(user)
 
-    def update(self, user_id: int, **fields: object) -> UserData | None:
+    def update(self, user_id: uuid.UUID, **fields: object) -> UserData | None:
         user = self.session.query(User).filter(User.id == user_id).first()
         if not user:
             return None
@@ -525,7 +530,7 @@ class UserRepository:
         return self._to_entity(user)
 
     def update_login_info(
-        self, user_id: int, github_id: int, email: str | None, avatar_url: str | None
+        self, user_id: uuid.UUID, github_id: int, email: str | None, avatar_url: str | None
     ) -> UserData | None:
         user = self.session.query(User).filter(User.id == user_id).first()
         if not user:
@@ -538,7 +543,7 @@ class UserRepository:
         self.session.refresh(user)
         return self._to_entity(user)
 
-    def delete(self, user_id: int) -> bool:
+    def delete(self, user_id: uuid.UUID) -> bool:
         user = self.session.query(User).filter(User.id == user_id).first()
         if not user:
             return False
@@ -551,14 +556,14 @@ class AiUsageLogRepository:
     def __init__(self, session: Session):
         self.session = session
 
-    def create(self, user_id: int, action: str) -> AiUsageLog:
+    def create(self, user_id: uuid.UUID, action: str) -> AiUsageLog:
         log = AiUsageLog(user_id=user_id, action=action)
         self.session.add(log)
         self.session.commit()
         self.session.refresh(log)
         return log
 
-    def count_today(self, user_id: int) -> int:
+    def count_today(self, user_id: uuid.UUID) -> int:
         today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
         return (
             self.session.query(func.count(AiUsageLog.id))
@@ -577,7 +582,7 @@ class AuditLogRepository:
         action: str,
         resource_type: str,
         resource_id: str | None = None,
-        user_id: int | None = None,
+        user_id: uuid.UUID | None = None,
         details: str | None = None,
         ip_address: str | None = None,
     ) -> AuditLog:
@@ -593,7 +598,7 @@ class AuditLogRepository:
         self.session.commit()
         return log
 
-    def get_by_user(self, user_id: int, limit: int = 100) -> list[AuditLog]:
+    def get_by_user(self, user_id: uuid.UUID, limit: int = 100) -> list[AuditLog]:
         return (
             self.session.query(AuditLog)
             .filter(AuditLog.user_id == user_id)
@@ -610,7 +615,9 @@ class DataConsentRepository:
     def __init__(self, session: Session):
         self.session = session
 
-    def grant(self, user_id: int, consent_type: str, policy_version: str = "1.0") -> DataConsent:
+    def grant(
+        self, user_id: uuid.UUID, consent_type: str, policy_version: str = "1.0"
+    ) -> DataConsent:
         existing = (
             self.session.query(DataConsent)
             .filter(
@@ -634,7 +641,7 @@ class DataConsentRepository:
         self.session.refresh(consent)
         return consent
 
-    def revoke(self, user_id: int, consent_type: str) -> bool:
+    def revoke(self, user_id: uuid.UUID, consent_type: str) -> bool:
         consent = (
             self.session.query(DataConsent)
             .filter(
@@ -651,7 +658,7 @@ class DataConsentRepository:
         self.session.commit()
         return True
 
-    def get_active_consents(self, user_id: int) -> list[DataConsent]:
+    def get_active_consents(self, user_id: uuid.UUID) -> list[DataConsent]:
         return (
             self.session.query(DataConsent)
             .filter(
@@ -662,7 +669,7 @@ class DataConsentRepository:
             .all()
         )
 
-    def has_consent(self, user_id: int, consent_type: str) -> bool:
+    def has_consent(self, user_id: uuid.UUID, consent_type: str) -> bool:
         return (
             self.session.query(DataConsent)
             .filter(
@@ -681,14 +688,14 @@ class DataRetentionRepository:
     def __init__(self, session: Session):
         self.session = session
 
-    def delete_user_extraction_data(self, user_id: int) -> int:
+    def delete_user_extraction_data(self, user_id: uuid.UUID) -> int:
         """Delete all extraction logs for a user. Returns count of deleted records."""
         count = self.session.query(ExtractionLog).filter(ExtractionLog.user_id == user_id).count()
         self.session.query(ExtractionLog).filter(ExtractionLog.user_id == user_id).delete()
         self.session.commit()
         return count
 
-    def delete_user_test_data(self, user_id: int) -> int:
+    def delete_user_test_data(self, user_id: uuid.UUID) -> int:
         count = (
             self.session.query(TestExtractionLog)
             .filter(TestExtractionLog.user_id == user_id)

--- a/backend/src/tests/conftest.py
+++ b/backend/src/tests/conftest.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,10 +9,20 @@ from src.infrastructure.auth import get_admin_user, get_current_user
 from src.infrastructure.database import get_db
 from src.main import app
 
+USER_UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+ADMIN_UUID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+GUEST_UUID = uuid.UUID("00000000-0000-0000-0000-000000000003")
+CONFIG_UUID = uuid.UUID("00000000-0000-0000-0000-000000000010")
+CONFIG_UUID_2 = uuid.UUID("00000000-0000-0000-0000-000000000011")
+VERSION_UUID = uuid.UUID("00000000-0000-0000-0000-000000000020")
+TOKEN_UUID = uuid.UUID("00000000-0000-0000-0000-000000000030")
+TOKEN_UUID_2 = uuid.UUID("00000000-0000-0000-0000-000000000031")
+LOG_UUID = uuid.UUID("00000000-0000-0000-0000-000000000040")
+
 
 def make_user(
     role: str = "user",
-    user_id: int = 1,
+    user_id: uuid.UUID = USER_UUID,
     is_active: bool = True,
     github_username: str = "testuser",
 ) -> UserData:
@@ -28,17 +39,17 @@ def make_user(
 
 @pytest.fixture()
 def fake_user():
-    return make_user(role="user", user_id=1)
+    return make_user(role="user", user_id=USER_UUID)
 
 
 @pytest.fixture()
 def fake_admin():
-    return make_user(role="admin", user_id=2, github_username="adminuser")
+    return make_user(role="admin", user_id=ADMIN_UUID, github_username="adminuser")
 
 
 @pytest.fixture()
 def fake_guest():
-    return make_user(role="guest", user_id=3, github_username="guestuser")
+    return make_user(role="guest", user_id=GUEST_UUID, github_username="guestuser")
 
 
 @pytest.fixture()

--- a/backend/src/tests/test_admin_routes.py
+++ b/backend/src/tests/test_admin_routes.py
@@ -1,11 +1,20 @@
+import uuid
 from unittest.mock import patch
 
-from src.tests.conftest import make_user
+from src.tests.conftest import ADMIN_UUID, USER_UUID, make_user
+
+USER_UUID_5 = uuid.UUID("00000000-0000-0000-0000-000000000005")
+USER_UUID_10 = uuid.UUID("00000000-0000-0000-0000-00000000000a")
+USER_UUID_99 = uuid.UUID("00000000-0000-0000-0000-000000000099")
+USER_UUID_999 = uuid.UUID("00000000-0000-0000-0000-000000000999")
 
 
 class TestListUsers:
     def test_admin_gets_users(self, admin_client):
-        users = [make_user(user_id=1), make_user(user_id=2, github_username="other")]
+        users = [
+            make_user(user_id=USER_UUID),
+            make_user(user_id=ADMIN_UUID, github_username="other"),
+        ]
         with patch("src.infrastructure.api.admin.routes.UserRepository") as MockRepo:
             MockRepo.return_value.get_all.return_value = users
             resp = admin_client.get("/admin/users")
@@ -19,7 +28,7 @@ class TestListUsers:
 
 class TestCreateUser:
     def test_creates_user(self, admin_client):
-        new_user = make_user(user_id=10, github_username="newuser")
+        new_user = make_user(user_id=USER_UUID_10, github_username="newuser")
         with patch("src.infrastructure.api.admin.routes.UserRepository") as MockRepo:
             MockRepo.return_value.get_by_github_username.return_value = None
             MockRepo.return_value.create.return_value = new_user
@@ -42,17 +51,17 @@ class TestCreateUser:
 
 class TestUpdateUser:
     def test_updates_user(self, admin_client):
-        updated = make_user(user_id=5, role="admin")
+        updated = make_user(user_id=USER_UUID_5, role="admin")
         with patch("src.infrastructure.api.admin.routes.UserRepository") as MockRepo:
             MockRepo.return_value.update.return_value = updated
-            resp = admin_client.put("/admin/users/5", json={"role": "admin"})
+            resp = admin_client.put(f"/admin/users/{USER_UUID_5}", json={"role": "admin"})
         assert resp.status_code == 200
         assert resp.json()["role"] == "admin"
 
     def test_not_found_returns_404(self, admin_client):
         with patch("src.infrastructure.api.admin.routes.UserRepository") as MockRepo:
             MockRepo.return_value.update.return_value = None
-            resp = admin_client.put("/admin/users/999", json={"role": "user"})
+            resp = admin_client.put(f"/admin/users/{USER_UUID_999}", json={"role": "user"})
         assert resp.status_code == 404
 
 
@@ -60,7 +69,7 @@ class TestDeleteUser:
     def test_deletes_user(self, admin_client, fake_admin):
         with patch("src.infrastructure.api.admin.routes.UserRepository") as MockRepo:
             MockRepo.return_value.delete.return_value = True
-            resp = admin_client.delete("/admin/users/99")
+            resp = admin_client.delete(f"/admin/users/{USER_UUID_99}")
         assert resp.status_code == 200
 
     def test_self_delete_returns_400(self, admin_client, fake_admin):
@@ -70,5 +79,5 @@ class TestDeleteUser:
     def test_not_found_returns_404(self, admin_client):
         with patch("src.infrastructure.api.admin.routes.UserRepository") as MockRepo:
             MockRepo.return_value.delete.return_value = False
-            resp = admin_client.delete("/admin/users/999")
+            resp = admin_client.delete(f"/admin/users/{USER_UUID_999}")
         assert resp.status_code == 404

--- a/backend/src/tests/test_auth.py
+++ b/backend/src/tests/test_auth.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
@@ -15,15 +16,18 @@ from src.infrastructure.auth import (
     get_current_user,
     hash_token,
 )
-from src.tests.conftest import make_user
+from src.tests.conftest import USER_UUID, make_user
+
+USER_UUID_42 = uuid.UUID("00000000-0000-0000-0000-000000000042")
+USER_UUID_5 = uuid.UUID("00000000-0000-0000-0000-000000000005")
 
 
 class TestCreateAccessToken:
     def test_valid_jwt_with_correct_claims(self):
-        user = make_user(role="user", user_id=42)
+        user = make_user(role="user", user_id=USER_UUID_42)
         token = create_access_token(user)
         payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
-        assert payload["user_id"] == 42
+        assert payload["user_id"] == str(USER_UUID_42)
         assert payload["role"] == "user"
         assert "exp" in payload
         assert "iat" in payload
@@ -56,19 +60,24 @@ class TestGenerateApiToken:
 
 
 class TestAuthenticateJwt:
-    def _make_token(self, user_id=1, role="user", expired=False):
+    def _make_token(self, user_id=USER_UUID, role="user", expired=False):
         exp = datetime.now(timezone.utc) + (timedelta(hours=-1) if expired else timedelta(hours=24))
-        payload = {"user_id": user_id, "role": role, "exp": exp, "iat": datetime.now(timezone.utc)}
+        payload = {
+            "user_id": str(user_id),
+            "role": role,
+            "exp": exp,
+            "iat": datetime.now(timezone.utc),
+        }
         return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
     def test_valid_token_returns_user(self):
-        token = self._make_token(user_id=5)
+        token = self._make_token(user_id=USER_UUID_5)
         db = MagicMock()
-        user = make_user(user_id=5)
+        user = make_user(user_id=USER_UUID_5)
         with patch("src.infrastructure.auth.UserRepository") as MockRepo:
             MockRepo.return_value.get_by_id.return_value = user
             result = _authenticate_jwt(token, db)
-        assert result.id == 5
+        assert result.id == USER_UUID_5
 
     def test_expired_token_raises_401(self):
         token = self._make_token(expired=True)
@@ -82,9 +91,9 @@ class TestAuthenticateJwt:
         assert exc_info.value.status_code == 401
 
     def test_inactive_user_raises_403(self):
-        token = self._make_token(user_id=5)
+        token = self._make_token(user_id=USER_UUID_5)
         db = MagicMock()
-        user = make_user(user_id=5, is_active=False)
+        user = make_user(user_id=USER_UUID_5, is_active=False)
         with patch("src.infrastructure.auth.UserRepository") as MockRepo:
             MockRepo.return_value.get_by_id.return_value = user
             with pytest.raises(HTTPException) as exc_info:

--- a/backend/src/tests/test_auth_routes.py
+++ b/backend/src/tests/test_auth_routes.py
@@ -1,6 +1,9 @@
+import uuid
 from unittest.mock import patch
 
 from src.tests.conftest import make_user
+
+USER_UUID_10 = uuid.UUID("00000000-0000-0000-0000-00000000000a")
 
 
 class TestGetMe:
@@ -8,7 +11,7 @@ class TestGetMe:
         resp = client.get("/auth/me")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["id"] == fake_user.id
+        assert data["id"] == str(fake_user.id)
         assert data["github_username"] == fake_user.github_username
         assert data["role"] == fake_user.role
 
@@ -52,7 +55,7 @@ class TestLogin:
             "email": "new@example.com",
             "avatar_url": "https://github.com/avatar.png",
         }
-        user = make_user(user_id=10, github_username="newuser")
+        user = make_user(user_id=USER_UUID_10, github_username="newuser")
         with (
             patch(
                 "src.infrastructure.api.auth.routes.validate_github_token",

--- a/backend/src/tests/test_extraction_routes.py
+++ b/backend/src/tests/test_extraction_routes.py
@@ -1,7 +1,11 @@
+import uuid
 from unittest.mock import MagicMock, patch
 
 from src.domain.entities import ApiCallResult, MetricsData
 from src.infrastructure.models import ExtractionLog
+from src.tests.conftest import CONFIG_UUID, LOG_UUID
+
+CONFIG_UUID_999 = uuid.UUID("00000000-0000-0000-0000-000000000999")
 
 
 class TestGetBanks:
@@ -17,7 +21,7 @@ class TestGetBanks:
 class TestExtractFromFile:
     def test_successful_extraction(self, client):
         config_data = MagicMock()
-        config_data.id = 1
+        config_data.id = CONFIG_UUID
         config_data.name = "test-config"
         config_data.output_schema = {"properties": {"field": {}}}
         config_data.is_default = False
@@ -52,7 +56,7 @@ class TestExtractFromFile:
                 json={
                     "s3_key": "test/file.pdf",
                     "filename": "file.pdf",
-                    "extractor_config_id": 1,
+                    "extractor_config_id": str(CONFIG_UUID),
                 },
             )
         assert resp.status_code == 200
@@ -74,7 +78,7 @@ class TestExtractFromFile:
                 json={
                     "s3_key": "test/file.pdf",
                     "filename": "file.pdf",
-                    "extractor_config_id": 999,
+                    "extractor_config_id": str(CONFIG_UUID_999),
                 },
             )
         assert resp.status_code == 404
@@ -83,14 +87,14 @@ class TestExtractFromFile:
 class TestSubmitExtraction:
     def test_records_submission(self, client):
         with patch("src.infrastructure.api.extraction.routes.ExtractionRepository") as MockRepo:
-            MockRepo.return_value.create.return_value = MagicMock(id=42)
+            MockRepo.return_value.create.return_value = MagicMock(id=LOG_UUID)
             resp = client.post(
                 "/extraction/submit",
                 json={
                     "filename": "test.pdf",
                     "extracted_fields": {"name": "Alice"},
                     "final_fields": {"name": "Alice"},
-                    "extractor_config_id": 1,
+                    "extractor_config_id": str(CONFIG_UUID),
                 },
             )
         assert resp.status_code == 200
@@ -99,7 +103,7 @@ class TestSubmitExtraction:
 class TestGetLogs:
     def test_returns_paginated_response(self, client):
         mock_log = MagicMock(spec=ExtractionLog)
-        mock_log.id = 1
+        mock_log.id = LOG_UUID
         mock_log.filename = "test.pdf"
         mock_log.extracted_fields = {}
         mock_log.final_fields = {}

--- a/backend/src/tests/test_extractor_config_service.py
+++ b/backend/src/tests/test_extractor_config_service.py
@@ -1,12 +1,18 @@
+import uuid
 from unittest.mock import MagicMock
 
 from src.domain.entities import ExtractorConfigData
 from src.domain.services.extractor_config import ExtractorConfigService
 
+CONFIG_UUID_1 = uuid.UUID("00000000-0000-0000-0000-000000000001")
+CONFIG_UUID_2 = uuid.UUID("00000000-0000-0000-0000-000000000002")
+CONFIG_UUID_3 = uuid.UUID("00000000-0000-0000-0000-000000000003")
+CONFIG_UUID_10 = uuid.UUID("00000000-0000-0000-0000-00000000000a")
+
 
 def _make_config(**overrides):
     defaults = dict(
-        id=1,
+        id=CONFIG_UUID_1,
         name="test",
         description="",
         prompt="extract",
@@ -35,38 +41,38 @@ class TestCreate:
         assert result.is_default is False
 
     def test_is_default_clears_others(self):
-        existing = _make_config(id=10, is_default=True)
+        existing = _make_config(id=CONFIG_UUID_10, is_default=True)
         service, repo = _make_service(configs=[existing])
         data = _make_config(id=None, is_default=True, status="active")
         service.create(data)
         # Should have called update on the existing default to clear it
-        repo.update.assert_any_call(10, existing)
+        repo.update.assert_any_call(CONFIG_UUID_10, existing)
         assert existing.is_default is False
 
 
 class TestUpdate:
     def test_draft_forces_is_default_false(self):
         service, repo = _make_service()
-        data = _make_config(id=1, status="draft", is_default=True)
-        result = service.update(1, data)
+        data = _make_config(id=CONFIG_UUID_1, status="draft", is_default=True)
+        result = service.update(CONFIG_UUID_1, data)
         assert result.is_default is False
 
     def test_clears_others_except_self(self):
-        other = _make_config(id=10, is_default=True)
-        self_config = _make_config(id=1, is_default=True)
+        other = _make_config(id=CONFIG_UUID_10, is_default=True)
+        self_config = _make_config(id=CONFIG_UUID_1, is_default=True)
         service, repo = _make_service(configs=[other, self_config])
-        data = _make_config(id=1, is_default=True, status="active")
-        service.update(1, data)
+        data = _make_config(id=CONFIG_UUID_1, is_default=True, status="active")
+        service.update(CONFIG_UUID_1, data)
         # other should have been cleared, self should not
         assert other.is_default is False
 
 
 class TestClearDefault:
     def test_clears_all_except_excluded(self):
-        c1 = _make_config(id=1, is_default=True)
-        c2 = _make_config(id=2, is_default=True)
-        c3 = _make_config(id=3, is_default=False)
+        c1 = _make_config(id=CONFIG_UUID_1, is_default=True)
+        c2 = _make_config(id=CONFIG_UUID_2, is_default=True)
+        c3 = _make_config(id=CONFIG_UUID_3, is_default=False)
         service, repo = _make_service(configs=[c1, c2, c3])
-        service._clear_default(exclude_id=1)
+        service._clear_default(exclude_id=CONFIG_UUID_1)
         assert c1.is_default is True  # excluded
         assert c2.is_default is False  # cleared

--- a/backend/src/tests/test_extractor_routes.py
+++ b/backend/src/tests/test_extractor_routes.py
@@ -1,11 +1,16 @@
+import uuid
 from unittest.mock import patch
 
 from src.domain.entities import ExtractorConfigData, QuotaExceededError
+from src.tests.conftest import CONFIG_UUID, CONFIG_UUID_2, USER_UUID
+
+CONFIG_UUID_5 = uuid.UUID("00000000-0000-0000-0000-000000000015")
+CONFIG_UUID_999 = uuid.UUID("00000000-0000-0000-0000-000000000999")
 
 
 def _make_config(**overrides):
     defaults = dict(
-        id=1,
+        id=CONFIG_UUID,
         name="test-extractor",
         description="A test extractor",
         prompt="Extract fields",
@@ -13,7 +18,7 @@ def _make_config(**overrides):
         output_schema={"type": "object", "properties": {"name": {"type": "string"}}},
         is_default=False,
         status="active",
-        user_id=1,
+        user_id=USER_UUID,
         created_at="2026-01-01T00:00:00",
         updated_at="2026-01-01T00:00:00",
     )
@@ -23,7 +28,7 @@ def _make_config(**overrides):
 
 class TestListExtractorConfigs:
     def test_lists_configs(self, client):
-        configs = [_make_config(id=1), _make_config(id=2, name="other")]
+        configs = [_make_config(id=CONFIG_UUID), _make_config(id=CONFIG_UUID_2, name="other")]
         with patch(
             "src.infrastructure.api.extractors.routes.ExtractorConfigRepository"
         ) as MockRepo:
@@ -44,7 +49,7 @@ class TestGetAvailableModels:
 
 class TestCreateExtractorConfig:
     def test_creates_config(self, client):
-        config = _make_config(id=5)
+        config = _make_config(id=CONFIG_UUID_5)
         with (
             patch("src.infrastructure.api.extractors.routes.ExtractorConfigRepository") as MockRepo,
             patch("src.infrastructure.api.extractors.routes.ApiCallRepository"),
@@ -104,8 +109,8 @@ class TestCreateExtractorConfig:
 
 class TestUpdateExtractorConfig:
     def test_updates_config(self, client):
-        existing = _make_config(id=1)
-        updated = _make_config(id=1, name="updated-name")
+        existing = _make_config(id=CONFIG_UUID)
+        updated = _make_config(id=CONFIG_UUID, name="updated-name")
         with patch(
             "src.infrastructure.api.extractors.routes.ExtractorConfigRepository"
         ) as MockRepo:
@@ -113,7 +118,7 @@ class TestUpdateExtractorConfig:
             MockRepo.return_value.get_all.return_value = []
             MockRepo.return_value.update.return_value = updated
             resp = client.put(
-                "/extractors/1",
+                f"/extractors/{CONFIG_UUID}",
                 json={"name": "updated-name"},
             )
         assert resp.status_code == 200
@@ -124,28 +129,28 @@ class TestUpdateExtractorConfig:
             "src.infrastructure.api.extractors.routes.ExtractorConfigRepository"
         ) as MockRepo:
             MockRepo.return_value.get_by_id.return_value = None
-            resp = client.put("/extractors/999", json={"name": "x"})
+            resp = client.put(f"/extractors/{CONFIG_UUID_999}", json={"name": "x"})
         assert resp.status_code == 404
 
 
 class TestDeleteExtractorConfig:
     def test_deletes_config(self, client):
-        config = _make_config(id=1, is_default=False)
+        config = _make_config(id=CONFIG_UUID, is_default=False)
         with patch(
             "src.infrastructure.api.extractors.routes.ExtractorConfigRepository"
         ) as MockRepo:
             MockRepo.return_value.get_by_id.return_value = config
             MockRepo.return_value.delete.return_value = True
-            resp = client.delete("/extractors/1")
+            resp = client.delete(f"/extractors/{CONFIG_UUID}")
         assert resp.status_code == 200
 
     def test_default_config_returns_400(self, client):
-        config = _make_config(id=1, is_default=True)
+        config = _make_config(id=CONFIG_UUID, is_default=True)
         with patch(
             "src.infrastructure.api.extractors.routes.ExtractorConfigRepository"
         ) as MockRepo:
             MockRepo.return_value.get_by_id.return_value = config
-            resp = client.delete("/extractors/1")
+            resp = client.delete(f"/extractors/{CONFIG_UUID}")
         assert resp.status_code == 400
 
     def test_not_found_returns_404(self, client):
@@ -153,5 +158,5 @@ class TestDeleteExtractorConfig:
             "src.infrastructure.api.extractors.routes.ExtractorConfigRepository"
         ) as MockRepo:
             MockRepo.return_value.get_by_id.return_value = None
-            resp = client.delete("/extractors/999")
+            resp = client.delete(f"/extractors/{CONFIG_UUID_999}")
         assert resp.status_code == 404

--- a/backend/src/tests/test_quota.py
+++ b/backend/src/tests/test_quota.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,8 +11,10 @@ from src.domain.services.quota import (
     QuotaService,
 )
 
+USER_UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 
-def _make_user(role: str = "guest", user_id: int = 1) -> UserData:
+
+def _make_user(role: str = "guest", user_id: uuid.UUID = USER_UUID) -> UserData:
     return UserData(
         id=user_id,
         github_id=None,

--- a/backend/src/tests/test_token_routes.py
+++ b/backend/src/tests/test_token_routes.py
@@ -1,12 +1,16 @@
+import uuid
 from unittest.mock import patch
 
 from src.domain.entities import ApiTokenData
 from src.infrastructure.auth import TOKEN_PREFIX
+from src.tests.conftest import TOKEN_UUID, TOKEN_UUID_2, USER_UUID
+
+TOKEN_UUID_999 = uuid.UUID("00000000-0000-0000-0000-000000000999")
 
 
 class TestCreateToken:
     def test_creates_token_with_prefix(self, client):
-        api_token = ApiTokenData(id=1, user_id=1, name="test-token")
+        api_token = ApiTokenData(id=TOKEN_UUID, user_id=USER_UUID, name="test-token")
         with (
             patch("src.infrastructure.api.tokens.routes.generate_api_token") as mock_gen,
             patch("src.infrastructure.api.tokens.routes.hash_token", return_value="hashed"),
@@ -26,8 +30,8 @@ class TestCreateToken:
 class TestListTokens:
     def test_lists_user_tokens(self, client):
         tokens = [
-            ApiTokenData(id=1, user_id=1, name="token-a"),
-            ApiTokenData(id=2, user_id=1, name="token-b"),
+            ApiTokenData(id=TOKEN_UUID, user_id=USER_UUID, name="token-a"),
+            ApiTokenData(id=TOKEN_UUID_2, user_id=USER_UUID, name="token-b"),
         ]
         with patch("src.infrastructure.api.tokens.routes.ApiTokenRepository") as MockRepo:
             MockRepo.return_value.get_by_user.return_value = tokens
@@ -40,11 +44,11 @@ class TestRevokeToken:
     def test_revokes_token(self, client):
         with patch("src.infrastructure.api.tokens.routes.ApiTokenRepository") as MockRepo:
             MockRepo.return_value.revoke.return_value = True
-            resp = client.delete("/tokens/1")
+            resp = client.delete(f"/tokens/{TOKEN_UUID}")
         assert resp.status_code == 200
 
     def test_not_found_returns_404(self, client):
         with patch("src.infrastructure.api.tokens.routes.ApiTokenRepository") as MockRepo:
             MockRepo.return_value.revoke.return_value = False
-            resp = client.delete("/tokens/999")
+            resp = client.delete(f"/tokens/{TOKEN_UUID_999}")
         assert resp.status_code == 404

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -38,15 +38,15 @@ export default function AdminUsersPage() {
     }
   };
 
-  const handleToggleActive = async (userId: number, currentActive: boolean) => {
+  const handleToggleActive = async (userId: string, currentActive: boolean) => {
     await updateUserMutation.mutateAsync({ id: userId, data: { is_active: !currentActive } });
   };
 
-  const handleChangeRole = async (userId: number, newRole: string) => {
+  const handleChangeRole = async (userId: string, newRole: string) => {
     await updateUserMutation.mutateAsync({ id: userId, data: { role: newRole } });
   };
 
-  const handleDelete = async (userId: number, username: string) => {
+  const handleDelete = async (userId: string, username: string) => {
     if (!confirm(t("admin.confirmDelete", { username }))) return;
     await deleteUserMutation.mutateAsync(userId);
   };

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -21,7 +21,7 @@ export default function Dashboard() {
   const t = useT();
 
   const configIdParam = useMemo(
-    () => selectedConfigId === "all" ? undefined : Number(selectedConfigId),
+    () => selectedConfigId === "all" ? undefined : selectedConfigId,
     [selectedConfigId]
   );
 

--- a/frontend/app/extractors/[id]/edit/page.tsx
+++ b/frontend/app/extractors/[id]/edit/page.tsx
@@ -15,7 +15,7 @@ import { useT } from "@/lib/i18n";
 export default function EditExtractorPage() {
   const params = useParams();
   const router = useRouter();
-  const configId = Number(params.id);
+  const configId = params.id as string;
   const t = useT();
 
   const { data: config, isLoading, error: loadError, refetch } = useExtractorConfig(configId);

--- a/frontend/app/extractors/new/page.tsx
+++ b/frontend/app/extractors/new/page.tsx
@@ -29,11 +29,11 @@ function NewExtractorContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const draftIdParam = searchParams.get("draft");
-  const draftId = draftIdParam ? Number(draftIdParam) : null;
+  const draftId = draftIdParam ?? null;
   const createMutation = useCreateExtractorConfig();
   const t = useT();
 
-  const { data: draftConfig, isLoading: draftLoading } = useExtractorConfig(draftId ?? 0, {
+  const { data: draftConfig, isLoading: draftLoading } = useExtractorConfig(draftId ?? "", {
     enabled: draftId !== null,
   });
 

--- a/frontend/app/extractors/page.tsx
+++ b/frontend/app/extractors/page.tsx
@@ -25,7 +25,7 @@ export default function ExtractorsPage() {
     quota.extractors.used >= quota.extractors.limit
   );
 
-  const handleDelete = async (id: number) => {
+  const handleDelete = async (id: string) => {
     if (!confirm(t("extractors.confirmDelete"))) return;
     try {
       await deleteMutation.mutateAsync(id);

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -199,7 +199,7 @@ export default function Home() {
           <Select
             value={selectedExtractorId?.toString() ?? ""}
             onValueChange={(v) => {
-              setSelectedExtractorId(Number(v));
+              setSelectedExtractorId(v);
               setExtracted(null);
               setFormData({});
               setError(null);

--- a/frontend/app/settings/tokens/page.tsx
+++ b/frontend/app/settings/tokens/page.tsx
@@ -83,7 +83,7 @@ export default function TokensPage() {
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const handleRevoke = async (tokenId: number, name: string) => {
+  const handleRevoke = async (tokenId: string, name: string) => {
     if (!confirm(t("tokens.confirmRevoke", { name }))) return;
     await revokeMutation.mutateAsync(tokenId);
   };

--- a/frontend/components/extractor-wizard/extractor-wizard.tsx
+++ b/frontend/components/extractor-wizard/extractor-wizard.tsx
@@ -27,7 +27,7 @@ interface WizardState {
 }
 
 interface DraftData {
-  id: number;
+  id: string;
   name: string;
   description: string | null;
   model: string;
@@ -90,7 +90,7 @@ export function ExtractorWizard({ onSave, onCancel, onDraftActivated, initialDra
   const [error, setError] = useState<string | null>(null);
   const [assistantOpen, setAssistantOpen] = useState(false);
   const [schemaVersion, setSchemaVersion] = useState(0);
-  const [draftId, setDraftId] = useState<number | null>(initialDraft?.id ?? null);
+  const [draftId, setDraftId] = useState<string | null>(initialDraft?.id ?? null);
   const draftCreating = useRef(false);
 
   const createConfig = useCreateExtractorConfig();
@@ -113,7 +113,7 @@ export function ExtractorWizard({ onSave, onCancel, onDraftActivated, initialDra
   }, []);
 
   const saveDraft = useCallback(
-    async (currentState: WizardState, existingDraftId: number | null) => {
+    async (currentState: WizardState, existingDraftId: string | null) => {
       if (existingDraftId) {
         try {
           await updateConfig.mutateAsync({

--- a/frontend/components/extractor-wizard/step-test.tsx
+++ b/frontend/components/extractor-wizard/step-test.tsx
@@ -13,7 +13,7 @@ interface StepTestProps {
   prompt: string;
   model: string;
   schema: Record<string, unknown>;
-  extractorConfigId?: number | null;
+  extractorConfigId?: string | null;
 }
 
 export function StepTest({ prompt, model, schema, extractorConfigId }: StepTestProps) {

--- a/frontend/components/version-history.tsx
+++ b/frontend/components/version-history.tsx
@@ -14,7 +14,7 @@ import { Loader2, RotateCcw } from "lucide-react";
 import { useT } from "@/lib/i18n";
 
 interface VersionHistoryProps {
-  configId: number;
+  configId: string;
   onRestore?: () => void;
 }
 
@@ -22,7 +22,7 @@ export function VersionHistory({ configId, onRestore }: VersionHistoryProps) {
   const { data: versions = [], isLoading } = useExtractorVersions(configId);
   const updateMutation = useUpdateExtractorConfig();
   const toggleMutation = useToggleVersionActive();
-  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const t = useT();
 
   const handleRestore = async (version: typeof versions[number]) => {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -59,9 +59,9 @@ async function throwIfError(response: Response, fallback: string): Promise<void>
 
 export interface ExtractionResult {
   fields: Record<string, unknown>;
-  extractor_config_id: number | null;
+  extractor_config_id: string | null;
   extractor_config_name: string;
-  extractor_config_version_id: number | null;
+  extractor_config_version_id: string | null;
   extractor_config_version_number: number | null;
 }
 
@@ -69,8 +69,8 @@ export interface SubmissionPayload {
   filename: string;
   extracted_fields: Record<string, string>;
   final_fields: Record<string, string>;
-  extractor_config_id?: number | null;
-  extractor_config_version_id?: number | null;
+  extractor_config_id?: string | null;
+  extractor_config_version_id?: string | null;
 }
 
 export interface Bank {
@@ -79,7 +79,7 @@ export interface Bank {
 }
 
 export interface ExtractionLog {
-  id: number;
+  id: string;
   timestamp: string;
   filename: string;
   extracted_fields: Record<string, string>;
@@ -123,7 +123,7 @@ export interface ApiCallMetrics {
 }
 
 export interface ExtractorConfig {
-  id: number;
+  id: string;
   name: string;
   description: string | null;
   prompt: string;
@@ -136,7 +136,7 @@ export interface ExtractorConfig {
 }
 
 export interface ExtractorConfigVersion {
-  id: number;
+  id: string;
   version_number: number;
   prompt: string;
   model: string;
@@ -155,7 +155,7 @@ export interface ModelInfo {
 
 // Auth
 export interface BackendUser {
-  id: number;
+  id: string;
   github_username: string;
   email: string | null;
   avatar_url: string | null;
@@ -209,7 +209,7 @@ export async function getUsageQuota(): Promise<UsageQuota> {
 
 // Admin
 export interface AdminUser {
-  id: number;
+  id: string;
   github_id: number | null;
   github_username: string;
   email: string | null;
@@ -234,7 +234,7 @@ export async function createUser(github_username: string, role: string = "user")
   return response.json();
 }
 
-export async function updateUser(id: number, data: { role?: string; is_active?: boolean }): Promise<AdminUser> {
+export async function updateUser(id: string, data: { role?: string; is_active?: boolean }): Promise<AdminUser> {
   const response = await authFetch(`${API_BASE_URL}/admin/users/${id}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
@@ -244,7 +244,7 @@ export async function updateUser(id: number, data: { role?: string; is_active?: 
   return response.json();
 }
 
-export async function deleteUser(id: number): Promise<void> {
+export async function deleteUser(id: string): Promise<void> {
   const response = await authFetch(`${API_BASE_URL}/admin/users/${id}`, { method: "DELETE" });
   if (!response.ok) throw new Error(await parseErrorDetail(response, "Failed to delete user"));
 }
@@ -308,7 +308,7 @@ export async function uploadFile(file: File): Promise<UploadResult> {
 }
 
 // Extraction
-export async function extractFromFile(s3Key: string, filename: string, extractorConfigId?: number | null): Promise<ExtractionResult> {
+export async function extractFromFile(s3Key: string, filename: string, extractorConfigId?: string | null): Promise<ExtractionResult> {
   const response = await authFetch(`${API_BASE_URL}/extraction/extract`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -342,7 +342,7 @@ export async function getBanks(): Promise<Bank[]> {
   return data.banks;
 }
 
-export async function getExtractionLogs(page: number = 1, pageSize: number = 50, extractorConfigId?: number | null): Promise<PaginatedLogsResponse> {
+export async function getExtractionLogs(page: number = 1, pageSize: number = 50, extractorConfigId?: string | null): Promise<PaginatedLogsResponse> {
   const params = new URLSearchParams({ page: String(page), page_size: String(pageSize) });
   if (extractorConfigId != null) params.set("extractor_config_id", String(extractorConfigId));
   const response = await authFetch(`${API_BASE_URL}/extraction/logs?${params}`);
@@ -350,14 +350,14 @@ export async function getExtractionLogs(page: number = 1, pageSize: number = 50,
   return response.json();
 }
 
-export async function getApiCallMetrics(extractorConfigId?: number | null): Promise<ApiCallMetrics> {
+export async function getApiCallMetrics(extractorConfigId?: string | null): Promise<ApiCallMetrics> {
   const params = extractorConfigId != null ? `?extractor_config_id=${extractorConfigId}` : "";
   const response = await authFetch(`${API_BASE_URL}/extraction/api-metrics${params}`);
   if (!response.ok) throw new Error("Failed to fetch API call metrics");
   return response.json();
 }
 
-export async function getMetrics(extractorConfigId?: number | null): Promise<Metrics> {
+export async function getMetrics(extractorConfigId?: string | null): Promise<Metrics> {
   const params = extractorConfigId != null ? `?extractor_config_id=${extractorConfigId}` : "";
   const response = await authFetch(`${API_BASE_URL}/extraction/metrics${params}`);
   if (!response.ok) throw new Error("Failed to fetch metrics");
@@ -373,7 +373,7 @@ export async function getExtractorConfigs(status?: string): Promise<ExtractorCon
   return data.configs;
 }
 
-export async function getExtractorConfig(id: number): Promise<ExtractorConfig> {
+export async function getExtractorConfig(id: string): Promise<ExtractorConfig> {
   const response = await authFetch(`${API_BASE_URL}/extractors/${id}`);
   if (!response.ok) throw new Error("Failed to fetch extractor config");
   return response.json();
@@ -397,7 +397,7 @@ export async function createExtractorConfig(config: {
   return response.json();
 }
 
-export async function updateExtractorConfig(id: number, config: {
+export async function updateExtractorConfig(id: string, config: {
   name?: string;
   description?: string;
   prompt?: string;
@@ -417,7 +417,7 @@ export async function updateExtractorConfig(id: number, config: {
   return response.json();
 }
 
-export async function deleteExtractorConfig(id: number): Promise<void> {
+export async function deleteExtractorConfig(id: string): Promise<void> {
   const response = await authFetch(`${API_BASE_URL}/extractors/${id}`, { method: "DELETE" });
   if (!response.ok) {
     throw new Error(await parseErrorDetail(response, "Failed to delete extractor config"));
@@ -430,7 +430,7 @@ export async function getAvailableModels(): Promise<ModelInfo[]> {
   return response.json();
 }
 
-export async function getExtractorVersions(id: number): Promise<ExtractorConfigVersion[]> {
+export async function getExtractorVersions(id: string): Promise<ExtractorConfigVersion[]> {
   const response = await authFetch(`${API_BASE_URL}/extractors/${id}/versions`);
   if (!response.ok) throw new Error("Failed to fetch versions");
   return response.json();
@@ -440,8 +440,8 @@ export async function testExtract(
   s3Key: string,
   filename: string,
   config: { prompt: string; model: string; output_schema: Record<string, unknown> },
-  extractorConfigId?: number | null
-): Promise<{ fields: Record<string, unknown>; response_time_ms: number; test_log_id: number | null }> {
+  extractorConfigId?: string | null
+): Promise<{ fields: Record<string, unknown>; response_time_ms: number; test_log_id: string | null }> {
   const response = await authFetch(`${API_BASE_URL}/extractors/test-extract`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -499,7 +499,7 @@ export async function updatePrompt(
 
 // API Tokens
 export interface ApiToken {
-  id: number;
+  id: string;
   name: string;
   created_at: string | null;
   expires_at: string | null;
@@ -509,7 +509,7 @@ export interface ApiToken {
 
 export interface CreateTokenResponse {
   token: string;
-  id: number;
+  id: string;
   name: string;
   expires_at: string | null;
 }
@@ -533,14 +533,14 @@ export async function createApiToken(
   return response.json();
 }
 
-export async function revokeApiToken(id: number): Promise<void> {
+export async function revokeApiToken(id: string): Promise<void> {
   const response = await authFetch(`${API_BASE_URL}/tokens/${id}`, { method: "DELETE" });
   if (!response.ok) throw new Error(await parseErrorDetail(response, "Failed to revoke token"));
 }
 
 export async function toggleVersionActive(
-  configId: number,
-  versionId: number,
+  configId: string,
+  versionId: string,
   isActive: boolean
 ): Promise<ExtractorConfigVersion> {
   const response = await authFetch(

--- a/frontend/lib/hooks.ts
+++ b/frontend/lib/hooks.ts
@@ -35,11 +35,11 @@ import {
 export const queryKeys = {
   banks: ["banks"] as const,
   extractorConfigs: ["extractorConfigs"] as const,
-  extractorConfig: (id: number) => ["extractorConfig", id] as const,
-  extractorVersions: (id: number) => ["extractorVersions", id] as const,
-  metrics: (configId?: number | null) => ["metrics", configId] as const,
-  apiCallMetrics: (configId?: number | null) => ["apiCallMetrics", configId] as const,
-  extractionLogs: (page: number, pageSize: number, configId?: number | null) =>
+  extractorConfig: (id: string) => ["extractorConfig", id] as const,
+  extractorVersions: (id: string) => ["extractorVersions", id] as const,
+  metrics: (configId?: string | null) => ["metrics", configId] as const,
+  apiCallMetrics: (configId?: string | null) => ["apiCallMetrics", configId] as const,
+  extractionLogs: (page: number, pageSize: number, configId?: string | null) =>
     ["extractionLogs", page, pageSize, configId] as const,
   availableModels: ["availableModels"] as const,
   apiTokens: ["apiTokens"] as const,
@@ -70,7 +70,7 @@ export function useExtractorConfigs(status?: string) {
   });
 }
 
-export function useExtractorConfig(id: number, options?: { enabled?: boolean }) {
+export function useExtractorConfig(id: string, options?: { enabled?: boolean }) {
   const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.extractorConfig(id),
@@ -79,7 +79,7 @@ export function useExtractorConfig(id: number, options?: { enabled?: boolean }) 
   });
 }
 
-export function useExtractorVersions(configId: number) {
+export function useExtractorVersions(configId: string) {
   const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.extractorVersions(configId),
@@ -88,7 +88,7 @@ export function useExtractorVersions(configId: number) {
   });
 }
 
-export function useMetrics(configId?: number | null) {
+export function useMetrics(configId?: string | null) {
   const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.metrics(configId),
@@ -97,7 +97,7 @@ export function useMetrics(configId?: number | null) {
   });
 }
 
-export function useApiCallMetrics(configId?: number | null) {
+export function useApiCallMetrics(configId?: string | null) {
   const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.apiCallMetrics(configId),
@@ -106,7 +106,7 @@ export function useApiCallMetrics(configId?: number | null) {
   });
 }
 
-export function useExtractionLogs(page: number, pageSize: number, configId?: number | null) {
+export function useExtractionLogs(page: number, pageSize: number, configId?: string | null) {
   const authed = useIsAuthenticated();
   return useQuery({
     queryKey: queryKeys.extractionLogs(page, pageSize, configId),
@@ -150,7 +150,7 @@ export function useExtract() {
     }: {
       s3Key: string;
       filename: string;
-      extractorConfigId?: number | null;
+      extractorConfigId?: string | null;
     }) => {
       return extractFromFile(s3Key, filename, extractorConfigId);
     },
@@ -175,7 +175,7 @@ export function useSubmitExtraction() {
 export function useDeleteExtractorConfig() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => deleteExtractorConfig(id),
+    mutationFn: (id: string) => deleteExtractorConfig(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.extractorConfigs });
     },
@@ -208,7 +208,7 @@ export function useUpdateExtractorConfig() {
       id,
       config,
     }: {
-      id: number;
+      id: string;
       config: {
         name?: string;
         description?: string;
@@ -235,8 +235,8 @@ export function useToggleVersionActive() {
       versionId,
       isActive,
     }: {
-      configId: number;
-      versionId: number;
+      configId: string;
+      versionId: string;
       isActive: boolean;
     }) => toggleVersionActive(configId, versionId, isActive),
     onSuccess: (_, { configId }) => {
@@ -254,7 +254,7 @@ export function useTestExtract() {
     }: {
       file: File;
       config: { prompt: string; model: string; output_schema: Record<string, unknown> };
-      extractorConfigId?: number | null;
+      extractorConfigId?: string | null;
     }) => {
       const { s3_key, filename } = await uploadFile(file);
       return testExtract(s3_key, filename, config, extractorConfigId);
@@ -330,7 +330,7 @@ export function useCreateApiToken() {
 export function useRevokeApiToken() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => revokeApiToken(id),
+    mutationFn: (id: string) => revokeApiToken(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.apiTokens });
     },
@@ -361,7 +361,7 @@ export function useCreateUser() {
 export function useUpdateUser() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: { role?: string; is_active?: boolean } }) =>
+    mutationFn: ({ id, data }: { id: string; data: { role?: string; is_active?: boolean } }) =>
       updateUser(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users });
@@ -372,7 +372,7 @@ export function useUpdateUser() {
 export function useDeleteUser() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => deleteUser(id),
+    mutationFn: (id: string) => deleteUser(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users });
     },

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -3,7 +3,7 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import { ExtractionResult } from "./api";
 
 interface AuthUser {
-  id: number;
+  id: string;
   github_username: string;
   email: string | null;
   avatar_url: string | null;
@@ -22,7 +22,7 @@ interface ExtractionState {
   uploadResult: UploadResult | null;
   extracted: ExtractionResult | null;
   formData: Record<string, string>;
-  selectedExtractorId: number | null;
+  selectedExtractorId: string | null;
   backendToken: string | null;
   backendUser: AuthUser | null;
   setFile: (file: File | null) => void;
@@ -30,7 +30,7 @@ interface ExtractionState {
   setExtracted: (extracted: ExtractionResult | null) => void;
   setFormData: (formData: Record<string, string>) => void;
   updateFormField: (field: string, value: string) => void;
-  setSelectedExtractorId: (id: number | null) => void;
+  setSelectedExtractorId: (id: string | null) => void;
   setBackendAuth: (token: string, user: AuthUser) => void;
   clearBackendAuth: () => void;
   reset: () => void;
@@ -43,7 +43,7 @@ const initialState = {
   uploadResult: null,
   extracted: null,
   formData: {} as Record<string, string>,
-  selectedExtractorId: null as number | null,
+  selectedExtractorId: null as string | null,
   backendToken: null as string | null,
   backendUser: null as AuthUser | null,
 };
@@ -99,7 +99,7 @@ export const useExtractionStore = create<ExtractionState>()(
         })),
     }),
     {
-      name: "extraction-storage",
+      name: "extraction-storage-v2",
       storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({
         fileName: state.fileName,


### PR DESCRIPTION
## Summary
- **Alembic migration**: Adds UUID columns alongside existing integer PKs, populates with `gen_random_uuid()`, backfills FK references via JOINs, swaps constraints, and drops old columns — all within a single PostgreSQL transaction (automatic rollback on failure)
- **Backend**: All ORM models, domain entities, services, repositories, DTOs, route parameters, and auth JWT payload updated from `int` to `uuid.UUID`
- **Frontend**: All TypeScript interfaces and function signatures changed from `number` to `string` for IDs. Zustand store key bumped to `v2` to invalidate cached integer IDs
- **SQLite removed**: Local dev now defaults to Docker PostgreSQL (`postgresql://postgres:postgres@localhost:5432/extractions`)

## Production deployment notes
- Migration runs automatically via `lifespan` on app startup
- **All existing JWT tokens will be invalidated** — users must re-login (JWT payload format changed from integer to UUID string)
- Frontend sessionStorage is auto-invalidated by the new store key
- Migration is wrapped in a transaction: if anything fails, it rolls back completely with no data loss
- Verified locally against Docker PostgreSQL with existing data — UUIDs generated, FK references preserved

## Test plan
- [x] 100 backend tests pass (all updated for UUID types)
- [x] Ruff lint clean
- [x] ESLint clean
- [x] Migration verified on local PostgreSQL with existing data
- [ ] Verify login flow works after deployment (re-login required)
- [ ] Verify extraction, extractor CRUD, dashboard, and admin pages work with UUID IDs in URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)