### PR TITLE
Add custom API documentation site

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "PyJWT>=2.8.0",
     "langchain-anthropic>=0.3.0",
     "cryptography>=46.0.5",
+    "jinja2>=3.1.6",
 ]
 
 [dependency-groups]

--- a/backend/src/infrastructure/api/docs/content.py
+++ b/backend/src/infrastructure/api/docs/content.py
@@ -1,0 +1,735 @@
+"""Documentation content for client-facing API endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Param:
+    name: str
+    location: str  # "body", "query", "path", "header"
+    type: str
+    required: bool
+    description: str
+
+
+@dataclass
+class CodeExample:
+    language: str  # "curl", "python", "javascript"
+    label: str
+    code: str
+
+
+@dataclass
+class Endpoint:
+    method: str
+    path: str
+    slug: str
+    title: str
+    description: str
+    group: str
+    params: list[Param] = field(default_factory=list)
+    request_body: str = ""
+    response_body: str = ""
+    examples: list[CodeExample] = field(default_factory=list)
+    notes: str = ""
+
+
+API_BASE_PLACEHOLDER = "$$API_BASE$$"
+API_BASE = API_BASE_PLACEHOLDER  # replaced at render time with actual request URL
+TOKEN_PLACEHOLDER = "exto_tu_token_aqui"
+
+GROUPS = [
+    ("tokens", "Tokens"),
+    ("extractors", "Extractores"),
+    ("extraction", "Extraccion"),
+]
+
+ENDPOINTS: list[Endpoint] = [
+    # ── Tokens ────────────────────────────────────────────────────────────
+    Endpoint(
+        method="POST",
+        path="/tokens",
+        slug="create-token",
+        title="Crear token",
+        group="tokens",
+        description=(
+            "Crea un nuevo token de API para autenticacion programatica. "
+            "El token solo se muestra una vez en la respuesta; guardalo de forma segura."
+        ),
+        params=[
+            Param("name", "body", "string", True, "Nombre descriptivo del token"),
+            Param(
+                "expires_at",
+                "body",
+                "string (ISO 8601)",
+                False,
+                "Fecha de expiracion (null = sin expiracion)",
+            ),
+        ],
+        request_body="""\
+{
+  "name": "mi-app-produccion",
+  "expires_at": "2026-12-31T23:59:59Z"
+}""",
+        response_body="""\
+{
+  "token": "exto_abc123...",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "mi-app-produccion",
+  "expires_at": "2026-12-31T23:59:59Z"
+}""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl -X POST {API_BASE}/tokens \\
+  -H "Authorization: Bearer {{JWT_TOKEN}}" \\
+  -H "Content-Type: application/json" \\
+  -d '{{"name": "mi-app-produccion"}}'""",
+            ),
+            CodeExample(
+                "python",
+                "Python",
+                f"""\
+import requests
+
+resp = requests.post(
+    "{API_BASE}/tokens",
+    headers={{"Authorization": "Bearer {{JWT_TOKEN}}"}},
+    json={{"name": "mi-app-produccion"}},
+)
+token = resp.json()["token"]
+print(f"Guarda este token: {{token}}")""",
+            ),
+            CodeExample(
+                "javascript",
+                "JavaScript",
+                f"""\
+const resp = await fetch("{API_BASE}/tokens", {{
+  method: "POST",
+  headers: {{
+    "Authorization": "Bearer {{JWT_TOKEN}}",
+    "Content-Type": "application/json",
+  }},
+  body: JSON.stringify({{ name: "mi-app-produccion" }}),
+}});
+const {{ token }} = await resp.json();
+console.log("Guarda este token:", token);""",
+            ),
+        ],
+        notes=(
+            "Los tokens se crean desde la interfaz web de Extracto en "
+            "<strong>Configuracion &rarr; Tokens API</strong>. "
+            "Este endpoint requiere autenticacion con JWT (sesion web), no con un API token. "
+            "Los usuarios invitados no pueden crear tokens."
+        ),
+    ),
+    Endpoint(
+        method="GET",
+        path="/tokens",
+        slug="list-tokens",
+        title="Listar tokens",
+        group="tokens",
+        description="Devuelve todos los tokens del usuario autenticado.",
+        response_body="""\
+[
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "mi-app-produccion",
+    "created_at": "2026-01-15T10:30:00",
+    "expires_at": "2026-12-31T23:59:59Z",
+    "last_used_at": "2026-03-20T14:22:00",
+    "is_revoked": false
+  }
+]""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl {API_BASE}/tokens \\
+  -H "Authorization: Bearer {{JWT_TOKEN}}" """,
+            ),
+        ],
+    ),
+    Endpoint(
+        method="DELETE",
+        path="/tokens/{token_id}",
+        slug="revoke-token",
+        title="Revocar token",
+        group="tokens",
+        description=(
+            "Revoca un token de API. Una vez revocado, no se puede usar para autenticarse."
+        ),
+        params=[
+            Param("token_id", "path", "UUID", True, "ID del token a revocar"),
+        ],
+        response_body='{ "detail": "Token revocado" }',
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl -X DELETE {API_BASE}/tokens/550e8400-e29b-41d4-a716-446655440000 \\
+  -H "Authorization: Bearer {{JWT_TOKEN}}" """,
+            ),
+        ],
+    ),
+    # ── Extractors ────────────────────────────────────────────────────────
+    Endpoint(
+        method="GET",
+        path="/extractors",
+        slug="list-extractors",
+        title="Listar extractores",
+        group="extractors",
+        description=(
+            "Devuelve los extractores configurados del usuario. "
+            "Cada extractor define un prompt, modelo, y schema de salida."
+        ),
+        params=[
+            Param("status", "query", "string", False, 'Filtrar por estado: "active" o "draft"'),
+        ],
+        response_body="""\
+{
+  "configs": [
+    {
+      "id": "a1b2c3d4-...",
+      "name": "Boletas y recibos",
+      "description": "Extrae datos de boletas",
+      "prompt": "Extrae los campos...",
+      "model": "claude-haiku-4-5-20251001",
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "titular": { "type": "string" },
+          "monto": { "type": "string" }
+        },
+        "required": ["titular", "monto"]
+      },
+      "is_default": true,
+      "status": "active",
+      "created_at": "2026-01-01T00:00:00",
+      "updated_at": "2026-01-15T12:00:00"
+    }
+  ]
+}""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl {API_BASE}/extractors \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" """,
+            ),
+            CodeExample(
+                "python",
+                "Python",
+                f"""\
+import requests
+
+resp = requests.get(
+    "{API_BASE}/extractors",
+    headers={{"Authorization": "Bearer {TOKEN_PLACEHOLDER}"}},
+)
+configs = resp.json()["configs"]
+for c in configs:
+    print(f"{{c['name']}} ({{c['id']}})")""",
+            ),
+            CodeExample(
+                "javascript",
+                "JavaScript",
+                f"""\
+const resp = await fetch("{API_BASE}/extractors", {{
+  headers: {{ "Authorization": "Bearer {TOKEN_PLACEHOLDER}" }},
+}});
+const {{ configs }} = await resp.json();
+configs.forEach(c => console.log(c.name, c.id));""",
+            ),
+        ],
+    ),
+    Endpoint(
+        method="GET",
+        path="/extractors/models",
+        slug="list-models",
+        title="Modelos disponibles",
+        group="extractors",
+        description="Devuelve la lista de modelos de IA disponibles para extraccion.",
+        response_body="""\
+[
+  {
+    "id": "claude-haiku-4-5-20251001",
+    "name": "Claude Haiku 4.5",
+    "tier": "fast",
+    "cost_hint": "$0.80 / $4.00 por 1M tokens",
+    "is_available": true
+  }
+]""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl {API_BASE}/extractors/models \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" """,
+            ),
+        ],
+    ),
+    Endpoint(
+        method="GET",
+        path="/extractors/{config_id}",
+        slug="get-extractor",
+        title="Obtener extractor",
+        group="extractors",
+        description="Devuelve los detalles de un extractor especifico por su ID.",
+        params=[
+            Param("config_id", "path", "UUID", True, "ID del extractor"),
+        ],
+        response_body="""\
+{
+  "id": "a1b2c3d4-...",
+  "name": "Boletas y recibos",
+  "description": "Extrae datos de boletas",
+  "prompt": "Extrae los campos...",
+  "model": "claude-haiku-4-5-20251001",
+  "output_schema": { ... },
+  "is_default": true,
+  "status": "active",
+  "created_at": "2026-01-01T00:00:00",
+  "updated_at": "2026-01-15T12:00:00"
+}""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl {API_BASE}/extractors/a1b2c3d4-... \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" """,
+            ),
+        ],
+    ),
+    Endpoint(
+        method="GET",
+        path="/extractors/{config_id}/versions",
+        slug="list-versions",
+        title="Listar versiones",
+        group="extractors",
+        description=(
+            "Devuelve las versiones de un extractor. Las versiones se crean automaticamente "
+            "al editar un extractor y permiten A/B testing."
+        ),
+        params=[
+            Param("config_id", "path", "UUID", True, "ID del extractor"),
+        ],
+        response_body="""\
+[
+  {
+    "id": "v1-uuid-...",
+    "version_number": 1,
+    "prompt": "Prompt original...",
+    "model": "claude-haiku-4-5-20251001",
+    "output_schema": { ... },
+    "is_active": false,
+    "created_at": "2026-01-01T00:00:00"
+  }
+]""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl {API_BASE}/extractors/a1b2c3d4-.../versions \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" """,
+            ),
+        ],
+    ),
+    # ── Extraction ────────────────────────────────────────────────────────
+    Endpoint(
+        method="POST",
+        path="/extraction/upload-url",
+        slug="upload-url",
+        title="Obtener URL de subida",
+        group="extraction",
+        description=(
+            "Genera una URL pre-firmada de S3 para subir un archivo directamente desde el "
+            "navegador o cliente. El archivo se sube con un PUT a la URL devuelta."
+        ),
+        params=[
+            Param("filename", "body", "string", True, 'Nombre del archivo (ej: "factura.pdf")'),
+            Param(
+                "content_type",
+                "body",
+                "string",
+                True,
+                'MIME type (ej: "application/pdf", "image/jpeg")',
+            ),
+        ],
+        request_body="""\
+{
+  "filename": "factura.pdf",
+  "content_type": "application/pdf"
+}""",
+        response_body="""\
+{
+  "s3_key": "uploads/abc123-factura.pdf",
+  "upload_url": "https://s3.amazonaws.com/bucket/uploads/abc123-factura.pdf?...",
+  "filename": "factura.pdf"
+}""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+# Paso 1: Obtener URL pre-firmada
+curl -X POST {API_BASE}/extraction/upload-url \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" \\
+  -H "Content-Type: application/json" \\
+  -d '{{"filename": "factura.pdf", "content_type": "application/pdf"}}'
+
+# Paso 2: Subir archivo a la URL devuelta
+curl -X PUT "{{upload_url}}" \\
+  -H "Content-Type: application/pdf" \\
+  --data-binary @factura.pdf""",
+            ),
+            CodeExample(
+                "python",
+                "Python",
+                f"""\
+import requests
+
+API = "{API_BASE}"
+TOKEN = "{TOKEN_PLACEHOLDER}"
+headers = {{"Authorization": f"Bearer {{TOKEN}}"}}
+
+# Paso 1: Obtener URL pre-firmada
+resp = requests.post(
+    f"{{API}}/extraction/upload-url",
+    headers=headers,
+    json={{"filename": "factura.pdf", "content_type": "application/pdf"}},
+)
+data = resp.json()
+s3_key = data["s3_key"]
+
+# Paso 2: Subir archivo
+with open("factura.pdf", "rb") as f:
+    requests.put(data["upload_url"], data=f, headers={{"Content-Type": "application/pdf"}})
+
+print(f"Archivo subido con clave: {{s3_key}}")""",
+            ),
+            CodeExample(
+                "javascript",
+                "JavaScript",
+                f"""\
+const API = "{API_BASE}";
+const TOKEN = "{TOKEN_PLACEHOLDER}";
+
+// Paso 1: Obtener URL pre-firmada
+const urlResp = await fetch(`${{API}}/extraction/upload-url`, {{
+  method: "POST",
+  headers: {{
+    "Authorization": `Bearer ${{TOKEN}}`,
+    "Content-Type": "application/json",
+  }},
+  body: JSON.stringify({{
+    filename: "factura.pdf",
+    content_type: "application/pdf",
+  }}),
+}});
+const {{ s3_key, upload_url }} = await urlResp.json();
+
+// Paso 2: Subir archivo
+await fetch(upload_url, {{
+  method: "PUT",
+  headers: {{ "Content-Type": "application/pdf" }},
+  body: fileBlob, // File o Blob
+}});
+
+console.log("Archivo subido con clave:", s3_key);""",
+            ),
+        ],
+    ),
+    Endpoint(
+        method="POST",
+        path="/extraction/upload",
+        slug="upload-file",
+        title="Subir archivo (fallback)",
+        group="extraction",
+        description=(
+            "Sube un archivo directamente al backend como multipart form-data. "
+            "Usa este endpoint como fallback cuando las URLs pre-firmadas no esten disponibles."
+        ),
+        params=[
+            Param("file", "body", "file (multipart)", True, "Archivo a subir"),
+        ],
+        request_body="(multipart/form-data con campo 'file')",
+        response_body="""\
+{
+  "s3_key": "uploads/abc123-factura.pdf",
+  "upload_url": null,
+  "filename": "factura.pdf"
+}""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl -X POST {API_BASE}/extraction/upload \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" \\
+  -F "file=@factura.pdf" """,
+            ),
+            CodeExample(
+                "python",
+                "Python",
+                f"""\
+import requests
+
+resp = requests.post(
+    "{API_BASE}/extraction/upload",
+    headers={{"Authorization": "Bearer {TOKEN_PLACEHOLDER}"}},
+    files={{"file": open("factura.pdf", "rb")}},
+)
+s3_key = resp.json()["s3_key"]""",
+            ),
+        ],
+    ),
+    Endpoint(
+        method="POST",
+        path="/extraction/extract",
+        slug="extract",
+        title="Extraer campos",
+        group="extraction",
+        description=(
+            "Ejecuta la extraccion de campos sobre un archivo previamente subido. "
+            "Usa el prompt y schema del extractor especificado (o el extractor por defecto). "
+            "Los campos extraidos son devueltos como un objeto JSON."
+        ),
+        params=[
+            Param("s3_key", "body", "string", True, "Clave S3 del archivo (de upload-url/upload)"),
+            Param("filename", "body", "string", True, "Nombre original del archivo"),
+            Param(
+                "extractor_config_id",
+                "body",
+                "UUID",
+                False,
+                "ID del extractor a usar (null = extractor por defecto)",
+            ),
+        ],
+        request_body="""\
+{
+  "s3_key": "uploads/abc123-factura.pdf",
+  "filename": "factura.pdf",
+  "extractor_config_id": "a1b2c3d4-..."
+}""",
+        response_body="""\
+{
+  "fields": {
+    "titular": "Juan Perez",
+    "monto": "$1,500.00",
+    "fecha": "2026-03-15"
+  },
+  "extractor_config_id": "a1b2c3d4-...",
+  "extractor_config_name": "Boletas y recibos",
+  "extractor_config_version_id": null,
+  "extractor_config_version_number": null
+}""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl -X POST {API_BASE}/extraction/extract \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" \\
+  -H "Content-Type: application/json" \\
+  -d '{{
+    "s3_key": "uploads/abc123-factura.pdf",
+    "filename": "factura.pdf",
+    "extractor_config_id": "a1b2c3d4-..."
+  }}'""",
+            ),
+            CodeExample(
+                "python",
+                "Python",
+                f"""\
+import requests
+
+resp = requests.post(
+    "{API_BASE}/extraction/extract",
+    headers={{
+        "Authorization": "Bearer {TOKEN_PLACEHOLDER}",
+        "Content-Type": "application/json",
+    }},
+    json={{
+        "s3_key": s3_key,
+        "filename": "factura.pdf",
+        "extractor_config_id": "a1b2c3d4-...",
+    }},
+)
+fields = resp.json()["fields"]
+for key, value in fields.items():
+    print(f"{{key}}: {{value}}")""",
+            ),
+            CodeExample(
+                "javascript",
+                "JavaScript",
+                """\
+const resp = await fetch(`${API}/extraction/extract`, {
+  method: "POST",
+  headers: {
+    "Authorization": `Bearer ${TOKEN}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    s3_key,
+    filename: "factura.pdf",
+    extractor_config_id: "a1b2c3d4-...",
+  }),
+});
+const { fields } = await resp.json();
+console.log(fields);""",
+            ),
+        ],
+        notes=(
+            "Si el documento no es compatible con el extractor, se devuelve un error 400. "
+            "Las extracciones via API se registran en el dashboard del usuario dueno del token."
+        ),
+    ),
+    Endpoint(
+        method="POST",
+        path="/extraction/submit",
+        slug="submit",
+        title="Enviar correccion",
+        group="extraction",
+        description=(
+            "Registra el resultado final de una extraccion, incluyendo las correcciones "
+            "del usuario. Esto alimenta las metricas de precision en el dashboard."
+        ),
+        params=[
+            Param("filename", "body", "string", True, "Nombre del archivo"),
+            Param(
+                "extracted_fields",
+                "body",
+                "object",
+                True,
+                "Campos tal como fueron extraidos por la IA",
+            ),
+            Param(
+                "final_fields",
+                "body",
+                "object",
+                True,
+                "Campos finales despues de correcciones del usuario",
+            ),
+            Param(
+                "extractor_config_id",
+                "body",
+                "UUID",
+                False,
+                "ID del extractor usado",
+            ),
+            Param(
+                "extractor_config_version_id",
+                "body",
+                "UUID",
+                False,
+                "ID de la version del extractor (si aplica)",
+            ),
+        ],
+        request_body="""\
+{
+  "filename": "factura.pdf",
+  "extracted_fields": {
+    "titular": "Juan Peres",
+    "monto": "$1,500.00"
+  },
+  "final_fields": {
+    "titular": "Juan Perez",
+    "monto": "$1,500.00"
+  },
+  "extractor_config_id": "a1b2c3d4-..."
+}""",
+        response_body="""\
+{
+  "message": "Submission recorded successfully",
+  "id": "log-uuid-..."
+}""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl -X POST {API_BASE}/extraction/submit \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" \\
+  -H "Content-Type: application/json" \\
+  -d '{{
+    "filename": "factura.pdf",
+    "extracted_fields": {{"titular": "Juan Peres", "monto": "$1,500.00"}},
+    "final_fields": {{"titular": "Juan Perez", "monto": "$1,500.00"}},
+    "extractor_config_id": "a1b2c3d4-..."
+  }}'""",
+            ),
+            CodeExample(
+                "python",
+                "Python",
+                f"""\
+import requests
+
+resp = requests.post(
+    "{API_BASE}/extraction/submit",
+    headers={{
+        "Authorization": "Bearer {TOKEN_PLACEHOLDER}",
+        "Content-Type": "application/json",
+    }},
+    json={{
+        "filename": "factura.pdf",
+        "extracted_fields": {{"titular": "Juan Peres", "monto": "$1,500.00"}},
+        "final_fields": {{"titular": "Juan Perez", "monto": "$1,500.00"}},
+        "extractor_config_id": "a1b2c3d4-...",
+    }},
+)
+print(resp.json())""",
+            ),
+        ],
+        notes=(
+            "El sistema compara <code>extracted_fields</code> con <code>final_fields</code> "
+            "para determinar que campos fueron corregidos. Esto se usa para calcular la "
+            "precision del extractor en el dashboard."
+        ),
+    ),
+    Endpoint(
+        method="GET",
+        path="/extraction/banks",
+        slug="banks",
+        title="Listar bancos",
+        group="extraction",
+        description="Devuelve la lista de bancos mexicanos soportados (nombre y codigo).",
+        response_body="""\
+{
+  "banks": [
+    { "name": "BBVA", "code": "012" },
+    { "name": "Banorte", "code": "072" },
+    ...
+  ]
+}""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl {API_BASE}/extraction/banks \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" """,
+            ),
+        ],
+    ),
+]
+
+
+def get_endpoints_by_group() -> list[tuple[str, str, list[Endpoint]]]:
+    """Return [(group_id, group_label, endpoints)] in display order."""
+    result = []
+    for gid, glabel in GROUPS:
+        eps = [e for e in ENDPOINTS if e.group == gid]
+        if eps:
+            result.append((gid, glabel, eps))
+    return result

--- a/backend/src/infrastructure/api/docs/router.py
+++ b/backend/src/infrastructure/api/docs/router.py
@@ -1,0 +1,70 @@
+"""Client API documentation pages served via Jinja2 templates."""
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from jinja2 import Environment, FileSystemLoader
+
+from src.infrastructure.api.docs.content import (
+    API_BASE_PLACEHOLDER,
+    ENDPOINTS,
+    get_endpoints_by_group,
+)
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+_env = Environment(loader=FileSystemLoader(str(_TEMPLATES_DIR)), autoescape=True)
+
+router = APIRouter(prefix="/api/docs", include_in_schema=False)
+
+_ENDPOINT_MAP = {ep.slug: ep for ep in ENDPOINTS}
+
+
+def _get_base_url(request: Request) -> str:
+    """Derive the public API base URL from the incoming request."""
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("x-forwarded-host", request.headers.get("host", ""))
+    return f"{scheme}://{host}"
+
+
+def _common_context(active_slug: str) -> dict:
+    return {
+        "groups": get_endpoints_by_group(),
+        "active_slug": active_slug,
+    }
+
+
+def _render(template_name: str, request: Request, **kwargs) -> HTMLResponse:
+    tpl = _env.get_template(template_name)
+    html = tpl.render(**kwargs)
+    html = html.replace(API_BASE_PLACEHOLDER, _get_base_url(request))
+    return HTMLResponse(html)
+
+
+@router.get("", response_class=HTMLResponse)
+async def docs_index(request: Request):
+    return _render(
+        "index.html", request, title="Inicio", **_common_context("index")
+    )
+
+
+@router.get("/{slug}", response_class=HTMLResponse)
+async def docs_endpoint(slug: str, request: Request):
+    ep = _ENDPOINT_MAP.get(slug)
+    if not ep:
+        raise HTTPException(status_code=404, detail="Pagina no encontrada")
+
+    # Prev/next navigation
+    idx = ENDPOINTS.index(ep)
+    prev_ep = ENDPOINTS[idx - 1] if idx > 0 else None
+    next_ep = ENDPOINTS[idx + 1] if idx < len(ENDPOINTS) - 1 else None
+
+    return _render(
+        "endpoint.html",
+        request,
+        title=ep.title,
+        endpoint=ep,
+        prev_endpoint=prev_ep,
+        next_endpoint=next_ep,
+        **_common_context(slug),
+    )

--- a/backend/src/infrastructure/api/docs/router.py
+++ b/backend/src/infrastructure/api/docs/router.py
@@ -43,9 +43,7 @@ def _render(template_name: str, request: Request, **kwargs) -> HTMLResponse:
 
 @router.get("", response_class=HTMLResponse)
 async def docs_index(request: Request):
-    return _render(
-        "index.html", request, title="Inicio", **_common_context("index")
-    )
+    return _render("index.html", request, title="Inicio", **_common_context("index"))
 
 
 @router.get("/{slug}", response_class=HTMLResponse)

--- a/backend/src/infrastructure/api/docs/templates/base.html
+++ b/backend/src/infrastructure/api/docs/templates/base.html
@@ -1,0 +1,438 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ title }} — Extracto API</title>
+  <style>
+    :root {
+      --bg: #0a0a0a;
+      --surface: #141414;
+      --surface-hover: #1a1a1a;
+      --border: #262626;
+      --text: #e5e5e5;
+      --text-muted: #a3a3a3;
+      --accent: #3b82f6;
+      --accent-hover: #60a5fa;
+      --green: #22c55e;
+      --yellow: #eab308;
+      --red: #ef4444;
+      --purple: #a855f7;
+      --code-bg: #1e1e1e;
+      --sidebar-w: 260px;
+      --radius: 8px;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+    }
+
+    /* ── Sidebar ─────────────────────────────── */
+    .sidebar {
+      position: fixed;
+      top: 0; left: 0;
+      width: var(--sidebar-w);
+      height: 100vh;
+      background: var(--surface);
+      border-right: 1px solid var(--border);
+      overflow-y: auto;
+      padding: 24px 0;
+      z-index: 10;
+    }
+
+    .sidebar-brand {
+      padding: 0 20px 20px;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 16px;
+    }
+
+    .sidebar-brand h1 {
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--text);
+    }
+
+    .sidebar-brand p {
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-top: 4px;
+    }
+
+    .sidebar-group {
+      margin-bottom: 8px;
+    }
+
+    .sidebar-group-title {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      padding: 8px 20px 4px;
+    }
+
+    .sidebar a {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 20px;
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 13px;
+      transition: all 0.15s;
+    }
+
+    .sidebar a:hover {
+      color: var(--text);
+      background: var(--surface-hover);
+    }
+
+    .sidebar a.active {
+      color: var(--accent);
+      background: rgba(59, 130, 246, 0.08);
+      border-right: 2px solid var(--accent);
+    }
+
+    .method-badge {
+      display: inline-block;
+      font-size: 10px;
+      font-weight: 700;
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-family: monospace;
+      min-width: 36px;
+      text-align: center;
+    }
+
+    .method-GET    { background: rgba(34,197,94,0.15); color: var(--green); }
+    .method-POST   { background: rgba(59,130,246,0.15); color: var(--accent); }
+    .method-PUT    { background: rgba(234,179,8,0.15); color: var(--yellow); }
+    .method-DELETE { background: rgba(239,68,68,0.15); color: var(--red); }
+    .method-PATCH  { background: rgba(168,85,247,0.15); color: var(--purple); }
+
+    /* ── Main ────────────────────────────────── */
+    .main {
+      margin-left: var(--sidebar-w);
+      min-height: 100vh;
+      padding: 48px 64px;
+      max-width: 900px;
+    }
+
+    h2 {
+      font-size: 28px;
+      font-weight: 700;
+      margin-bottom: 16px;
+    }
+
+    h3 {
+      font-size: 20px;
+      font-weight: 600;
+      margin: 32px 0 12px;
+    }
+
+    p {
+      color: var(--text-muted);
+      margin-bottom: 16px;
+    }
+
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { color: var(--accent-hover); text-decoration: underline; }
+
+    code {
+      font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+      font-size: 13px;
+      background: var(--code-bg);
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+
+    pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 16px 20px;
+      overflow-x: auto;
+      margin-bottom: 16px;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    pre code {
+      background: none;
+      padding: 0;
+    }
+
+    /* ── Card ────────────────────────────────── */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 24px;
+      margin-bottom: 16px;
+    }
+
+    /* ── Tabs ────────────────────────────────── */
+    .tabs {
+      display: flex;
+      gap: 0;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 0;
+    }
+
+    .tab-btn {
+      background: none;
+      border: none;
+      padding: 8px 16px;
+      color: var(--text-muted);
+      font-size: 13px;
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+      font-family: inherit;
+    }
+
+    .tab-btn:hover { color: var(--text); }
+    .tab-btn.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+
+    .tab-content pre {
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+      border-top: none;
+      margin-bottom: 0;
+    }
+
+    /* ── Params table ────────────────────────── */
+    .params-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+      margin-bottom: 16px;
+    }
+
+    .params-table th {
+      text-align: left;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border);
+      color: var(--text-muted);
+      font-weight: 600;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .params-table td {
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border);
+      color: var(--text);
+    }
+
+    .params-table td code {
+      font-size: 12px;
+    }
+
+    .required-badge {
+      font-size: 10px;
+      color: var(--red);
+      font-weight: 600;
+    }
+
+    .optional-badge {
+      font-size: 10px;
+      color: var(--text-muted);
+    }
+
+    /* ── Notes ───────────────────────────────── */
+    .note {
+      background: rgba(59,130,246,0.06);
+      border: 1px solid rgba(59,130,246,0.2);
+      border-radius: var(--radius);
+      padding: 12px 16px;
+      font-size: 13px;
+      color: var(--text-muted);
+      margin-bottom: 16px;
+    }
+
+    .note strong { color: var(--text); }
+
+    /* ── Endpoint header ─────────────────────── */
+    .endpoint-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+
+    .endpoint-header .method-badge {
+      font-size: 13px;
+      padding: 4px 10px;
+    }
+
+    .endpoint-path {
+      font-family: monospace;
+      font-size: 15px;
+      color: var(--text);
+    }
+
+    /* ── Responsive ──────────────────────────── */
+    @media (max-width: 768px) {
+      .sidebar { display: none; }
+      .main { margin-left: 0; padding: 24px; }
+    }
+
+    /* ── Footer ──────────────────────────────── */
+    .footer {
+      margin-top: 48px;
+      padding-top: 24px;
+      border-top: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    .footer a { color: var(--text-muted); }
+    .footer a:hover { color: var(--text); }
+    /* ── Prism overrides (match our dark theme) ── */
+    pre[class*="language-"] {
+      background: var(--code-bg) !important;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 16px 20px;
+      margin: 0 0 16px;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    code[class*="language-"] {
+      font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace !important;
+      font-size: 13px !important;
+    }
+
+    .tab-content pre[class*="language-"] {
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+      border-top: none;
+      margin-bottom: 0;
+    }
+
+    /* ── Copy button ─────────────────────────── */
+    .code-wrapper {
+      position: relative;
+    }
+
+    .copy-btn {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      background: var(--border);
+      border: none;
+      border-radius: 4px;
+      color: var(--text-muted);
+      font-size: 11px;
+      padding: 4px 8px;
+      cursor: pointer;
+      opacity: 0;
+      transition: opacity 0.15s;
+      font-family: inherit;
+      z-index: 1;
+    }
+
+    .code-wrapper:hover .copy-btn { opacity: 1; }
+    .copy-btn:hover { color: var(--text); background: var(--surface-hover); }
+    .copy-btn.copied { color: var(--green); }
+  </style>
+
+  <!-- Prism.js: One Dark theme + languages -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">
+</head>
+<body>
+
+<nav class="sidebar">
+  <div class="sidebar-brand">
+    <h1>Extracto API</h1>
+    <p>Documentacion para clientes</p>
+  </div>
+
+  <a href="/api/docs" {% if active_slug == "index" %}class="active"{% endif %}>Inicio</a>
+  <a href="/api/openapi.json" target="_blank">OpenAPI JSON</a>
+
+  {% for group_id, group_label, endpoints in groups %}
+  <div class="sidebar-group">
+    <div class="sidebar-group-title">{{ group_label }}</div>
+    {% for ep in endpoints %}
+    <a href="/api/docs/{{ ep.slug }}" {% if active_slug == ep.slug %}class="active"{% endif %}>
+      <span class="method-badge method-{{ ep.method }}">{{ ep.method }}</span>
+      {{ ep.title }}
+    </a>
+    {% endfor %}
+  </div>
+  {% endfor %}
+</nav>
+
+<main class="main">
+  {% block content %}{% endblock %}
+
+  <div class="footer">
+    <a href="/api/openapi.json">OpenAPI spec</a> &middot;
+    <a href="/docs">Documentacion interna (Swagger)</a>
+  </div>
+</main>
+
+<!-- Prism.js core + languages -->
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-bash.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-python.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-javascript.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-json.min.js"></script>
+
+<script>
+// Tab switching
+document.addEventListener("click", (e) => {
+  const btn = e.target.closest(".tab-btn");
+  if (!btn) return;
+  const group = btn.dataset.group;
+  const tab = btn.dataset.tab;
+  document.querySelectorAll(`.tab-btn[data-group="${group}"]`).forEach(b => b.classList.remove("active"));
+  document.querySelectorAll(`.tab-content[data-group="${group}"]`).forEach(c => c.classList.remove("active"));
+  btn.classList.add("active");
+  document.querySelector(`.tab-content[data-group="${group}"][data-tab="${tab}"]`).classList.add("active");
+});
+
+// Wrap every <pre> in a .code-wrapper with a copy button
+document.querySelectorAll("pre").forEach(pre => {
+  const wrapper = document.createElement("div");
+  wrapper.className = "code-wrapper";
+  pre.parentNode.insertBefore(wrapper, pre);
+  wrapper.appendChild(pre);
+
+  const btn = document.createElement("button");
+  btn.className = "copy-btn";
+  btn.textContent = "Copiar";
+  wrapper.appendChild(btn);
+
+  btn.addEventListener("click", () => {
+    const code = pre.querySelector("code");
+    const text = (code || pre).textContent;
+    navigator.clipboard.writeText(text).then(() => {
+      btn.textContent = "Copiado!";
+      btn.classList.add("copied");
+      setTimeout(() => {
+        btn.textContent = "Copiar";
+        btn.classList.remove("copied");
+      }, 2000);
+    });
+  });
+});
+</script>
+
+</body>
+</html>

--- a/backend/src/infrastructure/api/docs/templates/endpoint.html
+++ b/backend/src/infrastructure/api/docs/templates/endpoint.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="endpoint-header">
+  <span class="method-badge method-{{ endpoint.method }}">{{ endpoint.method }}</span>
+  <span class="endpoint-path">{{ endpoint.path }}</span>
+</div>
+
+<h2>{{ endpoint.title }}</h2>
+
+<p>{{ endpoint.description }}</p>
+
+{% if endpoint.notes %}
+<div class="note">{{ endpoint.notes | safe }}</div>
+{% endif %}
+
+{% if endpoint.params %}
+<h3>Parametros</h3>
+<div class="card" style="padding: 0; overflow: hidden;">
+  <table class="params-table" style="margin: 0;">
+    <thead>
+      <tr>
+        <th>Nombre</th>
+        <th>Ubicacion</th>
+        <th>Tipo</th>
+        <th></th>
+        <th>Descripcion</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for p in endpoint.params %}
+      <tr>
+        <td><code>{{ p.name }}</code></td>
+        <td>{{ p.location }}</td>
+        <td><code>{{ p.type }}</code></td>
+        <td>
+          {% if p.required %}
+          <span class="required-badge">requerido</span>
+          {% else %}
+          <span class="optional-badge">opcional</span>
+          {% endif %}
+        </td>
+        <td>{{ p.description }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+{% if endpoint.request_body %}
+<h3>Request body</h3>
+<pre><code class="language-json">{{ endpoint.request_body }}</code></pre>
+{% endif %}
+
+{% if endpoint.response_body %}
+<h3>Respuesta</h3>
+<pre><code class="language-json">{{ endpoint.response_body }}</code></pre>
+{% endif %}
+
+{% if endpoint.examples %}
+<h3>Ejemplos</h3>
+
+<div>
+  <div class="tabs">
+    {% for ex in endpoint.examples %}
+    <button class="tab-btn {% if loop.first %}active{% endif %}"
+            data-group="examples" data-tab="{{ ex.language }}">
+      {{ ex.label }}
+    </button>
+    {% endfor %}
+  </div>
+  {% for ex in endpoint.examples %}
+  <div class="tab-content {% if loop.first %}active{% endif %}"
+       data-group="examples" data-tab="{{ ex.language }}">
+    <pre><code class="language-{{ ex.language | replace('curl', 'bash') }}">{{ ex.code }}</code></pre>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+<div style="margin-top: 32px; display: flex; gap: 16px;">
+  {% if prev_endpoint %}
+  <a href="/api/docs/{{ prev_endpoint.slug }}" style="color: var(--text-muted);">
+    &larr; {{ prev_endpoint.title }}
+  </a>
+  {% endif %}
+  {% if next_endpoint %}
+  <a href="/api/docs/{{ next_endpoint.slug }}" style="margin-left: auto;">
+    {{ next_endpoint.title }} &rarr;
+  </a>
+  {% endif %}
+</div>
+
+{% endblock %}

--- a/backend/src/infrastructure/api/docs/templates/index.html
+++ b/backend/src/infrastructure/api/docs/templates/index.html
@@ -1,0 +1,335 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>Bienvenido a la API de Extracto</h2>
+
+<p>
+  Extracto permite extraer datos estructurados de documentos (PDF, imagenes)
+  usando modelos de IA. Esta documentacion cubre los endpoints disponibles
+  para integracion programatica con tu propio frontend o aplicacion.
+</p>
+
+<div class="card">
+  <h3 style="margin-top: 0;">Inicio rapido</h3>
+  <p>Para empezar a usar la API necesitas:</p>
+  <ol style="color: var(--text-muted); padding-left: 20px; margin-bottom: 16px;">
+    <li style="margin-bottom: 8px;">
+      <strong style="color: var(--text);">Obtener un token de API</strong> —
+      Crea uno desde la interfaz web en <em>Configuracion &rarr; Tokens API</em>,
+      o usa el endpoint <a href="/api/docs/create-token">POST /tokens</a>.
+    </li>
+    <li style="margin-bottom: 8px;">
+      <strong style="color: var(--text);">Elegir un extractor</strong> —
+      Lista tus extractores con <a href="/api/docs/list-extractors">GET /extractors</a>
+      y elige el ID del que quieras usar. Cada extractor define que campos se extraen
+      y con que modelo de IA.
+    </li>
+    <li style="margin-bottom: 8px;">
+      <strong style="color: var(--text);">Subir un archivo</strong> —
+      Obtén una URL pre-firmada con <a href="/api/docs/upload-url">POST /extraction/upload-url</a>
+      y sube el archivo directamente a S3.
+    </li>
+    <li style="margin-bottom: 8px;">
+      <strong style="color: var(--text);">Extraer campos</strong> —
+      Llama a <a href="/api/docs/extract">POST /extraction/extract</a> con la clave S3
+      y el ID del extractor para obtener los datos estructurados.
+    </li>
+    <li>
+      <strong style="color: var(--text);">Enviar correcciones</strong> (opcional) —
+      Si el usuario corrige algun campo, registra la correccion con
+      <a href="/api/docs/submit">POST /extraction/submit</a> para mejorar las metricas.
+    </li>
+  </ol>
+</div>
+
+<h3>Autenticacion</h3>
+
+<p>
+  Todos los endpoints requieren un header <code>Authorization</code> con un token Bearer:
+</p>
+
+<pre><code class="language-bash">Authorization: Bearer exto_tu_token_aqui</code></pre>
+
+<p>
+  Los tokens de API se identifican con el prefijo <code>exto_</code>.
+  Puedes crear y revocar tokens desde la interfaz web o via la API.
+</p>
+
+<div class="note">
+  <strong>Importante:</strong> Los endpoints de creacion de tokens
+  (<a href="/api/docs/create-token">POST /tokens</a>) requieren autenticacion
+  con sesion web (JWT), no con un API token. Todos los demas endpoints
+  aceptan ambos metodos.
+</div>
+
+<h3>Flujo completo de extraccion</h3>
+
+<p>Este diagrama muestra el flujo tipico para extraer datos de un documento:</p>
+
+<svg viewBox="0 0 720 480" fill="none" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;max-width:720px;margin:0 auto 16px;display:block;">
+
+  <!-- Row 1: Tu app → GET /extractors → elegir extractor_id -->
+
+  <!-- Step 1: Tu app -->
+  <rect x="20" y="24" width="130" height="48" rx="8" stroke="#3b82f6" stroke-width="1.5" fill="rgba(59,130,246,0.08)"/>
+  <text x="85" y="53" text-anchor="middle" fill="#e5e5e5" font-family="monospace" font-size="14" font-weight="600">Tu app</text>
+  <circle cx="36" cy="14" r="10" fill="#3b82f6"/>
+  <text x="36" y="18" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="11" font-weight="700">1</text>
+
+  <!-- Arrow 1→2 -->
+  <line x1="150" y1="48" x2="195" y2="48" stroke="#525252" stroke-width="1.5"/>
+  <polygon points="195,43 205,48 195,53" fill="#525252"/>
+
+  <!-- Step 2: GET /extractors -->
+  <rect x="205" y="24" width="180" height="48" rx="8" stroke="#22c55e" stroke-width="1.5" fill="rgba(34,197,94,0.08)"/>
+  <text x="295" y="45" text-anchor="middle" fill="#22c55e" font-family="monospace" font-size="11" font-weight="700">GET</text>
+  <text x="295" y="61" text-anchor="middle" fill="#e5e5e5" font-family="monospace" font-size="13">/extractors</text>
+  <circle cx="221" cy="14" r="10" fill="#22c55e"/>
+  <text x="221" y="18" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="11" font-weight="700">2</text>
+
+  <!-- Arrow 2→label -->
+  <line x1="385" y1="48" x2="415" y2="48" stroke="#525252" stroke-width="1.5"/>
+  <polygon points="415,43 425,48 415,53" fill="#525252"/>
+
+  <!-- extractor_id label -->
+  <text x="435" y="44" fill="#a855f7" font-family="monospace" font-size="12" font-weight="600">extractor_id</text>
+  <text x="435" y="60" fill="#a3a3a3" font-family="sans-serif" font-size="11">elegir extractor</text>
+
+  <!-- Row 2: POST /upload-url → PUT S3 -->
+
+  <!-- Arrow down from row 1 to row 2 -->
+  <line x1="295" y1="72" x2="295" y2="100" stroke="#525252" stroke-width="1.5"/>
+  <polygon points="290,100 295,110 300,100" fill="#525252"/>
+
+  <!-- Step 3: POST /upload-url -->
+  <rect x="205" y="110" width="180" height="48" rx="8" stroke="#3b82f6" stroke-width="1.5" fill="rgba(59,130,246,0.08)"/>
+  <text x="295" y="131" text-anchor="middle" fill="#3b82f6" font-family="monospace" font-size="11" font-weight="700">POST</text>
+  <text x="295" y="147" text-anchor="middle" fill="#e5e5e5" font-family="monospace" font-size="12">/extraction/upload-url</text>
+  <circle cx="221" cy="100" r="10" fill="#3b82f6"/>
+  <text x="221" y="104" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="11" font-weight="700">3</text>
+
+  <!-- Arrow 3→4 -->
+  <line x1="385" y1="134" x2="435" y2="134" stroke="#525252" stroke-width="1.5"/>
+  <polygon points="435,129 445,134 435,139" fill="#525252"/>
+
+  <!-- Step 4: PUT a S3 -->
+  <rect x="445" y="110" width="200" height="48" rx="8" stroke="#22c55e" stroke-width="1.5" fill="rgba(34,197,94,0.08)"/>
+  <text x="545" y="131" text-anchor="middle" fill="#22c55e" font-family="monospace" font-size="11" font-weight="700">PUT</text>
+  <text x="545" y="147" text-anchor="middle" fill="#e5e5e5" font-family="monospace" font-size="13">Subir archivo a S3</text>
+  <circle cx="461" cy="100" r="10" fill="#22c55e"/>
+  <text x="461" y="104" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="11" font-weight="700">4</text>
+
+  <!-- Arrow from S3 down+left to extract -->
+  <line x1="545" y1="158" x2="545" y2="195" stroke="#525252" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <line x1="545" y1="195" x2="385" y2="195" stroke="#525252" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <line x1="385" y1="195" x2="385" y2="220" stroke="#525252" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <polygon points="380,220 385,230 390,220" fill="#525252"/>
+
+  <!-- Step 5: POST /extract -->
+  <rect x="205" y="230" width="180" height="48" rx="8" stroke="#3b82f6" stroke-width="1.5" fill="rgba(59,130,246,0.08)"/>
+  <text x="295" y="251" text-anchor="middle" fill="#3b82f6" font-family="monospace" font-size="11" font-weight="700">POST</text>
+  <text x="295" y="267" text-anchor="middle" fill="#e5e5e5" font-family="monospace" font-size="13">/extraction/extract</text>
+  <circle cx="221" cy="220" r="10" fill="#3b82f6"/>
+  <text x="221" y="224" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="11" font-weight="700">5</text>
+
+  <!-- Params labels -->
+  <text x="400" y="243" fill="#a3a3a3" font-family="monospace" font-size="11">s3_key +</text>
+  <text x="400" y="258" fill="#a855f7" font-family="monospace" font-size="11">extractor_id</text>
+
+  <!-- Arrow 5→result -->
+  <line x1="295" y1="278" x2="295" y2="306" stroke="#525252" stroke-width="1.5"/>
+  <polygon points="290,306 295,316 300,306" fill="#525252"/>
+
+  <!-- Result: Campos extraidos -->
+  <rect x="205" y="316" width="180" height="48" rx="8" stroke="#eab308" stroke-width="1.5" fill="rgba(234,179,8,0.06)"/>
+  <text x="295" y="337" text-anchor="middle" fill="#eab308" font-family="monospace" font-size="11" font-weight="700">JSON</text>
+  <text x="295" y="353" text-anchor="middle" fill="#e5e5e5" font-family="monospace" font-size="13">Campos extraidos</text>
+
+  <!-- Arrow result→submit -->
+  <line x1="295" y1="364" x2="295" y2="392" stroke="#525252" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <polygon points="290,392 295,402 300,392" fill="#525252"/>
+
+  <!-- Step 6: POST /submit (optional) -->
+  <rect x="205" y="402" width="180" height="48" rx="8" stroke="#a3a3a3" stroke-width="1" stroke-dasharray="4,3" fill="rgba(163,163,163,0.04)"/>
+  <text x="295" y="423" text-anchor="middle" fill="#a3a3a3" font-family="monospace" font-size="11" font-weight="700">POST</text>
+  <text x="295" y="439" text-anchor="middle" fill="#a3a3a3" font-family="monospace" font-size="13">/extraction/submit</text>
+  <circle cx="221" cy="392" r="10" fill="#525252"/>
+  <text x="221" y="396" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="11" font-weight="700">6</text>
+
+  <!-- Optional label -->
+  <text x="400" y="430" fill="#a3a3a3" font-family="sans-serif" font-size="12" font-style="italic">opcional: registrar correcciones</text>
+</svg>
+
+<h3>Ejemplo completo en Python</h3>
+
+<pre><code class="language-python">import requests
+
+API = "$$API_BASE$$"
+TOKEN = "exto_tu_token_aqui"
+headers = {"Authorization": f"Bearer {TOKEN}"}
+
+# 1. Elegir extractor
+resp = requests.get(f"{API}/extractors", headers=headers)
+configs = resp.json()["configs"]
+for c in configs:
+    print(f"  {c['name']} ({c['id']}) — {c['status']}")
+# Usar el primero activo, o elegir por nombre
+extractor = next(c for c in configs if c["status"] == "active")
+extractor_id = extractor["id"]
+print(f"Usando extractor: {extractor['name']}")
+
+# 2. Obtener URL de subida
+resp = requests.post(
+    f"{API}/extraction/upload-url",
+    headers=headers,
+    json={"filename": "factura.pdf", "content_type": "application/pdf"},
+)
+data = resp.json()
+s3_key = data["s3_key"]
+
+# 3. Subir archivo a S3
+with open("factura.pdf", "rb") as f:
+    requests.put(data["upload_url"], data=f, headers={"Content-Type": "application/pdf"})
+
+# 4. Extraer campos con el extractor elegido
+resp = requests.post(
+    f"{API}/extraction/extract",
+    headers=headers,
+    json={
+        "s3_key": s3_key,
+        "filename": "factura.pdf",
+        "extractor_config_id": extractor_id,
+    },
+)
+fields = resp.json()["fields"]
+print(fields)
+# {"titular": "Juan Perez", "monto": "$1,500.00", "fecha": "2026-03-15"}
+
+# 5. (Opcional) Enviar correcciones
+corrected = {**fields, "titular": "Juan Pérez"}  # corregir acento
+requests.post(
+    f"{API}/extraction/submit",
+    headers=headers,
+    json={
+        "filename": "factura.pdf",
+        "extracted_fields": fields,
+        "final_fields": corrected,
+        "extractor_config_id": extractor_id,
+    },
+)</code></pre>
+
+<h3>Ejemplo completo en JavaScript</h3>
+
+<pre><code class="language-javascript">const API = "$$API_BASE$$";
+const TOKEN = "exto_tu_token_aqui";
+const headers = {
+  "Authorization": `Bearer ${TOKEN}`,
+  "Content-Type": "application/json",
+};
+
+// 1. Elegir extractor
+const cfgResp = await fetch(`${API}/extractors`, { headers });
+const { configs } = await cfgResp.json();
+configs.forEach(c => console.log(`  ${c.name} (${c.id}) — ${c.status}`));
+// Usar el primero activo, o elegir por nombre
+const extractor = configs.find(c => c.status === "active");
+const extractorId = extractor.id;
+console.log("Usando extractor:", extractor.name);
+
+// 2. Obtener URL de subida
+const urlResp = await fetch(`${API}/extraction/upload-url`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    filename: "factura.pdf",
+    content_type: "application/pdf",
+  }),
+});
+const { s3_key, upload_url } = await urlResp.json();
+
+// 3. Subir archivo a S3
+await fetch(upload_url, {
+  method: "PUT",
+  headers: { "Content-Type": "application/pdf" },
+  body: file, // File object del input
+});
+
+// 4. Extraer campos con el extractor elegido
+const extractResp = await fetch(`${API}/extraction/extract`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    s3_key,
+    filename: "factura.pdf",
+    extractor_config_id: extractorId,
+  }),
+});
+const { fields } = await extractResp.json();
+console.log(fields);
+
+// 5. (Opcional) Enviar correcciones
+await fetch(`${API}/extraction/submit`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    filename: "factura.pdf",
+    extracted_fields: fields,
+    final_fields: { ...fields, titular: "Juan Pérez" },
+    extractor_config_id: extractorId,
+  }),
+});</code></pre>
+
+<h3>Codigos de error comunes</h3>
+
+<div class="card" style="padding: 0; overflow: hidden;">
+  <table class="params-table" style="margin: 0;">
+    <thead>
+      <tr>
+        <th>Codigo</th>
+        <th>Significado</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>400</code></td>
+        <td>Solicitud invalida (archivo no soportado, campos faltantes, documento incompatible)</td>
+      </tr>
+      <tr>
+        <td><code>401</code></td>
+        <td>Token invalido o expirado</td>
+      </tr>
+      <tr>
+        <td><code>403</code></td>
+        <td>Sin permisos (ej: invitado intentando crear token)</td>
+      </tr>
+      <tr>
+        <td><code>404</code></td>
+        <td>Recurso no encontrado (extractor, archivo, token)</td>
+      </tr>
+      <tr>
+        <td><code>429</code></td>
+        <td>Limite de uso excedido (cuota diaria de extracciones)</td>
+      </tr>
+      <tr>
+        <td><code>500</code></td>
+        <td>Error interno del servidor</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<h3>Tipos de archivo soportados</h3>
+
+<p>
+  La API acepta los siguientes formatos de archivo:
+</p>
+
+<ul style="color: var(--text-muted); padding-left: 20px; margin-bottom: 16px;">
+  <li><code>application/pdf</code> — Documentos PDF</li>
+  <li><code>image/jpeg</code> — Imagenes JPEG</li>
+  <li><code>image/png</code> — Imagenes PNG</li>
+  <li><code>image/webp</code> — Imagenes WebP</li>
+</ul>
+
+{% endblock %}

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -11,8 +11,7 @@ sys.path.insert(0, str(project_root))
 from alembic.config import Config
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
-from fastapi.openapi.docs import get_swagger_ui_html
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
@@ -21,6 +20,7 @@ from src.core.logger import get_logger
 from src.domain.entities import QuotaExceededError
 from src.infrastructure.api.admin.routes import router as admin_router
 from src.infrastructure.api.auth.routes import router as auth_router
+from src.infrastructure.api.docs.router import router as docs_router
 from src.infrastructure.api.extraction.routes import router as extraction_router
 from src.infrastructure.api.extractors.routes import router as extractors_router
 from src.infrastructure.api.privacy.routes import router as privacy_router
@@ -90,7 +90,7 @@ class DynamicCORSMiddleware(BaseHTTPMiddleware):
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Adds security headers to all responses (HSTS, CSP, X-Content-Type-Options, etc.)."""
 
-    DOCS_PATHS = {"/docs", "/api/docs", "/redoc"}
+    DOCS_PATHS_PREFIXES = ("/docs", "/api/docs", "/redoc")
     DOCS_CSP = (
         "default-src 'self'; "
         "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
@@ -107,7 +107,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["X-XSS-Protection"] = "1; mode=block"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-        if request.url.path in self.DOCS_PATHS:
+        if any(request.url.path.startswith(p) for p in self.DOCS_PATHS_PREFIXES):
             response.headers["Content-Security-Policy"] = self.DOCS_CSP
         else:
             response.headers["Content-Security-Policy"] = self.DEFAULT_CSP
@@ -139,6 +139,7 @@ app.include_router(extraction_router)
 app.include_router(extractors_router)
 app.include_router(tokens_router)
 app.include_router(privacy_router)
+app.include_router(docs_router)
 
 
 AUDITED_PATHS = {"/extraction/extract", "/extraction/submit", "/extraction/logs", "/admin/users"}
@@ -292,14 +293,6 @@ def get_client_openapi_schema() -> dict:
 @app.get("/api/openapi.json", include_in_schema=False)
 async def client_openapi():
     return JSONResponse(get_client_openapi_schema())
-
-
-@app.get("/api/docs", include_in_schema=False, response_class=HTMLResponse)
-async def client_docs():
-    return get_swagger_ui_html(
-        openapi_url="/api/openapi.json",
-        title="Extracto Client API",
-    )
 
 
 @app.get("/")

--- a/backend/src/tests/test_docs.py
+++ b/backend/src/tests/test_docs.py
@@ -1,0 +1,277 @@
+"""Tests to verify that the client API documentation matches the actual API."""
+
+import json
+import re
+
+import pytest
+
+from src.infrastructure.api.docs.content import ENDPOINTS, get_endpoints_by_group
+from src.main import CLIENT_ENDPOINT_WHITELIST, get_client_openapi_schema
+
+
+class TestDocsPages:
+    """Verify documentation pages load correctly."""
+
+    def test_index_page_loads(self, client):
+        resp = client.get("/api/docs")
+        assert resp.status_code == 200
+        assert "Extracto API" in resp.text
+
+    def test_each_endpoint_page_loads(self, client):
+        for ep in ENDPOINTS:
+            resp = client.get(f"/api/docs/{ep.slug}")
+            assert resp.status_code == 200, f"Page /api/docs/{ep.slug} failed"
+            assert ep.title in resp.text
+
+    def test_invalid_slug_returns_404(self, client):
+        resp = client.get("/api/docs/nonexistent-endpoint")
+        assert resp.status_code == 404
+
+    def test_openapi_json_loads(self, client):
+        resp = client.get("/api/openapi.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "paths" in data
+        assert "info" in data
+
+
+class TestDocsMatchWhitelist:
+    """Verify documented endpoints match the CLIENT_ENDPOINT_WHITELIST in main.py."""
+
+    def test_all_whitelisted_endpoints_are_documented(self):
+        """Every endpoint in CLIENT_ENDPOINT_WHITELIST should have a docs page."""
+        documented = {(ep.method, ep.path) for ep in ENDPOINTS}
+        for method, path in CLIENT_ENDPOINT_WHITELIST:
+            assert (method, path) in documented, (
+                f"({method}, {path}) is in CLIENT_ENDPOINT_WHITELIST "
+                f"but missing from docs content.py"
+            )
+
+    def test_all_documented_endpoints_are_whitelisted(self):
+        """Every documented endpoint should exist in CLIENT_ENDPOINT_WHITELIST."""
+        for ep in ENDPOINTS:
+            assert (ep.method, ep.path) in CLIENT_ENDPOINT_WHITELIST, (
+                f"({ep.method}, {ep.path}) is documented in docs "
+                f"but missing from CLIENT_ENDPOINT_WHITELIST"
+            )
+
+
+class TestDocsMatchOpenAPI:
+    """Verify documented endpoints match the actual OpenAPI spec."""
+
+    @pytest.fixture()
+    def openapi_spec(self):
+        return get_client_openapi_schema()
+
+    def test_all_documented_paths_exist_in_openapi(self, openapi_spec):
+        """Every documented endpoint should exist in the OpenAPI spec."""
+        spec_paths = openapi_spec.get("paths", {})
+        for ep in ENDPOINTS:
+            assert ep.path in spec_paths, (
+                f"Documented path {ep.path} not found in OpenAPI spec. "
+                f"Available: {list(spec_paths.keys())}"
+            )
+            methods = spec_paths[ep.path]
+            assert ep.method.lower() in methods, (
+                f"Documented method {ep.method} for {ep.path} not in OpenAPI. "
+                f"Available: {list(methods.keys())}"
+            )
+
+    def test_documented_query_params_match_openapi(self, openapi_spec):
+        """Query parameters documented should exist in the OpenAPI spec."""
+        spec_paths = openapi_spec.get("paths", {})
+        for ep in ENDPOINTS:
+            query_params = [p for p in ep.params if p.location == "query"]
+            if not query_params:
+                continue
+
+            operation = spec_paths.get(ep.path, {}).get(ep.method.lower(), {})
+            spec_params = operation.get("parameters", [])
+            spec_query_names = {
+                p["name"] for p in spec_params if p.get("in") == "query"
+            }
+
+            for param in query_params:
+                assert param.name in spec_query_names, (
+                    f"Documented query param '{param.name}' for "
+                    f"{ep.method} {ep.path} not found in OpenAPI. "
+                    f"Available: {spec_query_names}"
+                )
+
+    def test_documented_path_params_match_openapi(self, openapi_spec):
+        """Path parameters documented should exist in the OpenAPI spec."""
+        spec_paths = openapi_spec.get("paths", {})
+        for ep in ENDPOINTS:
+            path_params = [p for p in ep.params if p.location == "path"]
+            if not path_params:
+                continue
+
+            operation = spec_paths.get(ep.path, {}).get(ep.method.lower(), {})
+            spec_params = operation.get("parameters", [])
+            spec_path_names = {
+                p["name"] for p in spec_params if p.get("in") == "path"
+            }
+
+            for param in path_params:
+                assert param.name in spec_path_names, (
+                    f"Documented path param '{param.name}' for "
+                    f"{ep.method} {ep.path} not found in OpenAPI. "
+                    f"Available: {spec_path_names}"
+                )
+
+    def test_documented_body_params_match_openapi(self, openapi_spec):
+        """Body parameters documented should exist in the request body schema."""
+        spec_paths = openapi_spec.get("paths", {})
+        schemas = openapi_spec.get("components", {}).get("schemas", {})
+
+        for ep in ENDPOINTS:
+            body_params = [p for p in ep.params if p.location == "body"]
+            if not body_params:
+                continue
+
+            operation = spec_paths.get(ep.path, {}).get(ep.method.lower(), {})
+            request_body = operation.get("requestBody", {})
+            if not request_body:
+                continue
+
+            # Resolve the schema (may be a $ref)
+            content = request_body.get("content", {})
+            json_schema = content.get("application/json", {}).get("schema", {})
+
+            if "$ref" in json_schema:
+                ref_name = json_schema["$ref"].split("/")[-1]
+                json_schema = schemas.get(ref_name, {})
+
+            schema_props = json_schema.get("properties", {})
+            if not schema_props:
+                continue
+
+            for param in body_params:
+                # Skip file params (multipart)
+                if "file" in param.type.lower() or "multipart" in param.type.lower():
+                    continue
+                assert param.name in schema_props, (
+                    f"Documented body param '{param.name}' for "
+                    f"{ep.method} {ep.path} not found in OpenAPI schema. "
+                    f"Available: {list(schema_props.keys())}"
+                )
+
+    @staticmethod
+    def _normalize_json(text: str) -> str:
+        """Replace placeholder patterns so the JSON can be parsed."""
+        # Replace "value..." patterns inside strings
+        text = re.sub(r'"([^"]*)\.\.\."', r'"\1_placeholder"', text)
+        # Replace { ... } (object placeholder) with empty object
+        text = re.sub(r'\{\s*\.\.\.\s*\}', '{}', text)
+        # Replace standalone ...  (e.g. as object value)
+        text = text.replace("...", '"__placeholder__"')
+        return text
+
+    def test_response_bodies_are_valid_json(self):
+        """All documented response bodies should be valid JSON."""
+        for ep in ENDPOINTS:
+            if not ep.response_body:
+                continue
+            body = self._normalize_json(ep.response_body)
+            try:
+                json.loads(body)
+            except json.JSONDecodeError:
+                pytest.fail(
+                    f"Response body for {ep.method} {ep.path} "
+                    f"is not valid JSON:\n{ep.response_body}"
+                )
+
+    def test_request_bodies_are_valid_json(self):
+        """All documented request bodies should be valid JSON (where applicable)."""
+        for ep in ENDPOINTS:
+            if not ep.request_body:
+                continue
+            body = ep.request_body
+            # Skip multipart descriptions
+            if "multipart" in body.lower():
+                continue
+            body = self._normalize_json(body)
+            try:
+                json.loads(body)
+            except json.JSONDecodeError:
+                pytest.fail(
+                    f"Request body for {ep.method} {ep.path} "
+                    f"is not valid JSON:\n{ep.request_body}"
+                )
+
+
+class TestDocsContent:
+    """Verify documentation content quality."""
+
+    def test_all_endpoints_have_descriptions(self):
+        for ep in ENDPOINTS:
+            assert ep.description, f"{ep.method} {ep.path} has no description"
+
+    def test_all_endpoints_have_at_least_one_example(self):
+        for ep in ENDPOINTS:
+            assert len(ep.examples) >= 1, (
+                f"{ep.method} {ep.path} has no code examples"
+            )
+
+    def test_all_endpoints_have_unique_slugs(self):
+        slugs = [ep.slug for ep in ENDPOINTS]
+        assert len(slugs) == len(set(slugs)), (
+            f"Duplicate slugs found: {[s for s in slugs if slugs.count(s) > 1]}"
+        )
+
+    def test_all_groups_have_endpoints(self):
+        groups = get_endpoints_by_group()
+        for gid, glabel, eps in groups:
+            assert len(eps) > 0, f"Group '{glabel}' has no endpoints"
+
+    def test_sidebar_nav_has_all_endpoints(self, client):
+        """The sidebar on the index page should link to every endpoint."""
+        resp = client.get("/api/docs")
+        for ep in ENDPOINTS:
+            assert f"/api/docs/{ep.slug}" in resp.text, (
+                f"Sidebar missing link to /api/docs/{ep.slug}"
+            )
+
+
+class TestDynamicBaseUrl:
+    """Verify the API base URL placeholder is replaced with the actual host."""
+
+    def test_index_has_no_placeholder(self, client):
+        resp = client.get("/api/docs")
+        assert "$$API_BASE$$" not in resp.text, "Placeholder not replaced on index"
+
+    def test_endpoint_pages_have_no_placeholder(self, client):
+        for ep in ENDPOINTS:
+            resp = client.get(f"/api/docs/{ep.slug}")
+            assert "$$API_BASE$$" not in resp.text, (
+                f"Placeholder not replaced on /api/docs/{ep.slug}"
+            )
+
+    def test_index_contains_resolved_url(self, client):
+        """The rendered page should contain the testserver host, not a placeholder."""
+        resp = client.get("/api/docs")
+        assert "http://testserver" in resp.text
+
+    def test_endpoint_page_contains_resolved_url(self, client):
+        resp = client.get("/api/docs/extract")
+        assert "http://testserver" in resp.text
+
+
+class TestIndexExamples:
+    """Verify the full examples on the index page show the complete flow."""
+
+    def test_python_example_lists_extractors(self, client):
+        resp = client.get("/api/docs")
+        assert "/extractors" in resp.text, "Python example missing GET /extractors"
+
+    def test_python_example_uses_extractor_id(self, client):
+        resp = client.get("/api/docs")
+        assert "extractor_id" in resp.text, (
+            "Python example missing extractor_id in extract call"
+        )
+
+    def test_quick_start_mentions_extractor_step(self, client):
+        resp = client.get("/api/docs")
+        assert "Elegir un extractor" in resp.text or "Elegir extractor" in resp.text, (
+            "Quick start missing extractor selection step"
+        )

--- a/backend/src/tests/test_docs.py
+++ b/backend/src/tests/test_docs.py
@@ -87,9 +87,7 @@ class TestDocsMatchOpenAPI:
 
             operation = spec_paths.get(ep.path, {}).get(ep.method.lower(), {})
             spec_params = operation.get("parameters", [])
-            spec_query_names = {
-                p["name"] for p in spec_params if p.get("in") == "query"
-            }
+            spec_query_names = {p["name"] for p in spec_params if p.get("in") == "query"}
 
             for param in query_params:
                 assert param.name in spec_query_names, (
@@ -108,9 +106,7 @@ class TestDocsMatchOpenAPI:
 
             operation = spec_paths.get(ep.path, {}).get(ep.method.lower(), {})
             spec_params = operation.get("parameters", [])
-            spec_path_names = {
-                p["name"] for p in spec_params if p.get("in") == "path"
-            }
+            spec_path_names = {p["name"] for p in spec_params if p.get("in") == "path"}
 
             for param in path_params:
                 assert param.name in spec_path_names, (
@@ -162,7 +158,7 @@ class TestDocsMatchOpenAPI:
         # Replace "value..." patterns inside strings
         text = re.sub(r'"([^"]*)\.\.\."', r'"\1_placeholder"', text)
         # Replace { ... } (object placeholder) with empty object
-        text = re.sub(r'\{\s*\.\.\.\s*\}', '{}', text)
+        text = re.sub(r"\{\s*\.\.\.\s*\}", "{}", text)
         # Replace standalone ...  (e.g. as object value)
         text = text.replace("...", '"__placeholder__"')
         return text
@@ -195,8 +191,7 @@ class TestDocsMatchOpenAPI:
                 json.loads(body)
             except json.JSONDecodeError:
                 pytest.fail(
-                    f"Request body for {ep.method} {ep.path} "
-                    f"is not valid JSON:\n{ep.request_body}"
+                    f"Request body for {ep.method} {ep.path} is not valid JSON:\n{ep.request_body}"
                 )
 
 
@@ -209,9 +204,7 @@ class TestDocsContent:
 
     def test_all_endpoints_have_at_least_one_example(self):
         for ep in ENDPOINTS:
-            assert len(ep.examples) >= 1, (
-                f"{ep.method} {ep.path} has no code examples"
-            )
+            assert len(ep.examples) >= 1, f"{ep.method} {ep.path} has no code examples"
 
     def test_all_endpoints_have_unique_slugs(self):
         slugs = [ep.slug for ep in ENDPOINTS]
@@ -266,9 +259,7 @@ class TestIndexExamples:
 
     def test_python_example_uses_extractor_id(self, client):
         resp = client.get("/api/docs")
-        assert "extractor_id" in resp.text, (
-            "Python example missing extractor_id in extract call"
-        )
+        assert "extractor_id" in resp.text, "Python example missing extractor_id in extract call"
 
     def test_quick_start_mentions_extractor_step(self, client):
         resp = client.get("/api/docs")

--- a/backend/src/tests/test_docs_examples.py
+++ b/backend/src/tests/test_docs_examples.py
@@ -1,0 +1,583 @@
+"""Test that the documented API examples actually work against the real endpoints.
+
+Each test sends the exact request body from the docs and verifies:
+- The endpoint returns the expected status code
+- The response contains all documented fields
+"""
+
+import json
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.domain.entities import (
+    ApiCallResult,
+    ApiTokenData,
+    ExtractorConfigData,
+    ExtractorConfigVersionData,
+)
+from src.infrastructure.api.docs.content import ENDPOINTS
+from src.infrastructure.auth import TOKEN_PREFIX
+from src.tests.conftest import (
+    CONFIG_UUID,
+    CONFIG_UUID_2,
+    LOG_UUID,
+    TOKEN_UUID,
+    USER_UUID,
+    VERSION_UUID,
+)
+
+
+def _parse_doc_json(text: str) -> dict | list:
+    """Parse a documentation JSON body, replacing placeholders."""
+    text = re.sub(r'"([^"]*)\.\.\."', r'"\1placeholder"', text)
+    text = re.sub(r'\{\s*\.\.\.\s*\}', '{}', text)
+    text = text.replace("...", '"__placeholder__"')
+    return json.loads(text)
+
+
+def _get_doc_endpoint(method: str, path: str):
+    """Find a documented endpoint by method and path."""
+    for ep in ENDPOINTS:
+        if ep.method == method and ep.path == path:
+            return ep
+    pytest.fail(f"Documented endpoint {method} {path} not found")
+
+
+def _response_keys(ep) -> set[str]:
+    """Extract top-level keys from a documented response body."""
+    if not ep.response_body:
+        return set()
+    parsed = _parse_doc_json(ep.response_body)
+    if isinstance(parsed, dict):
+        return set(parsed.keys())
+    if isinstance(parsed, list) and parsed:
+        return set(parsed[0].keys())
+    return set()
+
+
+# ── Tokens ────────────────────────────────────────────────────────────────────
+
+
+class TestTokenExamples:
+    def test_create_token(self, client):
+        ep = _get_doc_endpoint("POST", "/tokens")
+        request_body = _parse_doc_json(ep.request_body)
+
+        api_token = ApiTokenData(
+            id=TOKEN_UUID,
+            user_id=USER_UUID,
+            name=request_body["name"],
+            expires_at=request_body.get("expires_at"),
+        )
+        with (
+            patch("src.infrastructure.api.tokens.routes.generate_api_token") as mock_gen,
+            patch("src.infrastructure.api.tokens.routes.hash_token", return_value="h"),
+            patch("src.infrastructure.api.tokens.routes.ApiTokenRepository") as MockRepo,
+        ):
+            mock_gen.return_value = f"{TOKEN_PREFIX}abc123"
+            MockRepo.return_value.create.return_value = api_token
+            resp = client.post("/tokens", json=request_body)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        doc_keys = _response_keys(ep)
+        assert doc_keys.issubset(data.keys()), (
+            f"Response missing documented keys: {doc_keys - data.keys()}"
+        )
+        assert data["token"].startswith(TOKEN_PREFIX)
+
+    def test_list_tokens(self, client):
+        ep = _get_doc_endpoint("GET", "/tokens")
+
+        tokens = [
+            ApiTokenData(id=TOKEN_UUID, user_id=USER_UUID, name="token-a"),
+        ]
+        with patch("src.infrastructure.api.tokens.routes.ApiTokenRepository") as MockRepo:
+            MockRepo.return_value.get_by_user.return_value = tokens
+            resp = client.get("/tokens")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        doc_keys = _response_keys(ep)
+        assert doc_keys.issubset(data[0].keys()), (
+            f"Response missing documented keys: {doc_keys - data[0].keys()}"
+        )
+
+    def test_revoke_token(self, client):
+        _get_doc_endpoint("DELETE", "/tokens/{token_id}")
+
+        with patch("src.infrastructure.api.tokens.routes.ApiTokenRepository") as MockRepo:
+            MockRepo.return_value.revoke.return_value = True
+            resp = client.delete(f"/tokens/{TOKEN_UUID}")
+
+        assert resp.status_code == 200
+        assert "detail" in resp.json()
+
+
+# ── Extractors ────────────────────────────────────────────────────────────────
+
+
+def _make_config(**overrides):
+    defaults = dict(
+        id=CONFIG_UUID,
+        name="Boletas y recibos",
+        description="Extrae datos de boletas",
+        prompt="Extrae los campos",
+        model="claude-haiku-4-5-20251001",
+        output_schema={
+            "type": "object",
+            "properties": {"titular": {"type": "string"}, "monto": {"type": "string"}},
+            "required": ["titular", "monto"],
+        },
+        is_default=True,
+        status="active",
+        user_id=USER_UUID,
+        created_at="2026-01-01T00:00:00",
+        updated_at="2026-01-15T12:00:00",
+    )
+    defaults.update(overrides)
+    return ExtractorConfigData(**defaults)
+
+
+class TestExtractorExamples:
+    def test_list_extractors(self, client):
+        ep = _get_doc_endpoint("GET", "/extractors")
+
+        configs = [_make_config()]
+        with patch(
+            "src.infrastructure.api.extractors.routes.ExtractorConfigRepository"
+        ) as MockRepo:
+            MockRepo.return_value.get_all.return_value = configs
+            resp = client.get("/extractors")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "configs" in data
+        config = data["configs"][0]
+        doc_response = _parse_doc_json(ep.response_body)
+        doc_config_keys = set(doc_response["configs"][0].keys())
+        assert doc_config_keys.issubset(config.keys()), (
+            f"Response missing documented keys: {doc_config_keys - config.keys()}"
+        )
+
+    def test_get_models(self, client):
+        ep = _get_doc_endpoint("GET", "/extractors/models")
+
+        resp = client.get("/extractors/models")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        doc_keys = _response_keys(ep)
+        assert doc_keys.issubset(data[0].keys()), (
+            f"Response missing documented keys: {doc_keys - data[0].keys()}"
+        )
+
+    def test_get_extractor(self, client):
+        ep = _get_doc_endpoint("GET", "/extractors/{config_id}")
+
+        config = _make_config()
+        with patch(
+            "src.infrastructure.api.extractors.routes.ExtractorConfigRepository"
+        ) as MockRepo:
+            MockRepo.return_value.get_by_id.return_value = config
+            resp = client.get(f"/extractors/{CONFIG_UUID}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        doc_keys = _response_keys(ep)
+        assert doc_keys.issubset(data.keys()), (
+            f"Response missing documented keys: {doc_keys - data.keys()}"
+        )
+
+    def test_list_versions(self, client):
+        ep = _get_doc_endpoint("GET", "/extractors/{config_id}/versions")
+
+        config = _make_config()
+        version = ExtractorConfigVersionData(
+            id=VERSION_UUID,
+            extractor_config_id=CONFIG_UUID,
+            version_number=1,
+            prompt="Prompt original",
+            model="claude-haiku-4-5-20251001",
+            output_schema={"type": "object", "properties": {}},
+            is_active=False,
+            created_at="2026-01-01T00:00:00",
+        )
+        with patch(
+            "src.infrastructure.api.extractors.routes.ExtractorConfigRepository"
+        ) as MockRepo:
+            MockRepo.return_value.get_by_id.return_value = config
+            MockRepo.return_value.get_versions.return_value = [version]
+            resp = client.get(f"/extractors/{CONFIG_UUID}/versions")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        doc_keys = _response_keys(ep)
+        assert doc_keys.issubset(data[0].keys()), (
+            f"Response missing documented keys: {doc_keys - data[0].keys()}"
+        )
+
+
+# ── Extraction ────────────────────────────────────────────────────────────────
+
+
+class TestExtractionExamples:
+    def test_upload_url(self, client):
+        ep = _get_doc_endpoint("POST", "/extraction/upload-url")
+        request_body = _parse_doc_json(ep.request_body)
+
+        with patch("src.infrastructure.api.extraction.routes.get_storage") as mock_storage:
+            mock_storage.return_value.generate_upload_url.return_value = (
+                "https://s3.amazonaws.com/bucket/uploads/key?signed"
+            )
+            resp = client.post("/extraction/upload-url", json=request_body)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        doc_keys = _response_keys(ep)
+        assert doc_keys.issubset(data.keys()), (
+            f"Response missing documented keys: {doc_keys - data.keys()}"
+        )
+        assert data["filename"] == request_body["filename"]
+        assert data["s3_key"]  # non-empty
+
+    def test_extract(self, client):
+        ep = _get_doc_endpoint("POST", "/extraction/extract")
+        # Build a valid request body (use real UUIDs, not placeholder)
+        request_body = {
+            "s3_key": "uploads/abc123-factura.pdf",
+            "filename": "factura.pdf",
+            "extractor_config_id": str(CONFIG_UUID),
+        }
+
+        config = _make_config()
+        call_result = ApiCallResult(model="claude-haiku-4-5-20251001", success=True,
+                                    response_time_ms=150.0)
+
+        with (
+            patch("src.infrastructure.api.extraction.routes.get_storage") as mock_storage,
+            patch("src.infrastructure.api.extraction.routes.ExtractionService") as MockService,
+            patch(
+                "src.infrastructure.api.extraction.routes.ExtractorConfigRepository"
+            ) as MockConfigRepo,
+            patch("src.infrastructure.api.extraction.routes.ApiCallRepository"),
+            patch("src.infrastructure.api.extraction.routes.AiUsageLogRepository"),
+            patch("src.infrastructure.api.extraction.routes.QuotaService") as MockQuota,
+        ):
+            MockQuota.return_value.check_extraction_quota.return_value = None
+            mock_storage.return_value.download.return_value = b"pdf-bytes"
+            MockService.return_value.extract.return_value = (
+                {"titular": "Juan Perez", "monto": "$1,500.00", "fecha": "2026-03-15"},
+                call_result,
+                None,
+            )
+            MockConfigRepo.return_value.get_by_id.return_value = config
+            MockConfigRepo.return_value.get_active_versions.return_value = []
+
+            resp = client.post("/extraction/extract", json=request_body)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        doc_keys = _response_keys(ep)
+        assert doc_keys.issubset(data.keys()), (
+            f"Response missing documented keys: {doc_keys - data.keys()}"
+        )
+        assert isinstance(data["fields"], dict)
+        assert data["extractor_config_id"] is not None
+        assert data["extractor_config_name"] is not None
+
+    def test_submit(self, client):
+        ep = _get_doc_endpoint("POST", "/extraction/submit")
+        # Use a real UUID instead of placeholder
+        request_body = {
+            "filename": "factura.pdf",
+            "extracted_fields": {"titular": "Juan Peres", "monto": "$1,500.00"},
+            "final_fields": {"titular": "Juan Perez", "monto": "$1,500.00"},
+            "extractor_config_id": str(CONFIG_UUID),
+        }
+
+        with patch(
+            "src.infrastructure.api.extraction.routes.ExtractionRepository"
+        ) as MockRepo:
+            MockRepo.return_value.create.return_value = MagicMock(id=LOG_UUID)
+            resp = client.post("/extraction/submit", json=request_body)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        doc_keys = _response_keys(ep)
+        assert doc_keys.issubset(data.keys()), (
+            f"Response missing documented keys: {doc_keys - data.keys()}"
+        )
+        assert data["message"]
+        assert data["id"]
+
+    def test_banks(self, client):
+        ep = _get_doc_endpoint("GET", "/extraction/banks")
+
+        resp = client.get("/extraction/banks")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "banks" in data
+        assert isinstance(data["banks"], list)
+        assert len(data["banks"]) > 0
+        doc_response = _parse_doc_json(ep.response_body)
+        doc_bank_keys = set(doc_response["banks"][0].keys())
+        assert doc_bank_keys.issubset(data["banks"][0].keys()), (
+            f"Response missing documented keys: {doc_bank_keys - data['banks'][0].keys()}"
+        )
+
+    def test_upload_fallback(self, client):
+        ep = _get_doc_endpoint("POST", "/extraction/upload")
+
+        with patch("src.infrastructure.api.extraction.routes.get_storage") as mock_storage:
+            mock_storage.return_value.save.return_value = None
+            resp = client.post(
+                "/extraction/upload",
+                files={"file": ("factura.pdf", b"fake-pdf-bytes", "application/pdf")},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        doc_keys = _response_keys(ep)
+        assert doc_keys.issubset(data.keys()), (
+            f"Response missing documented keys: {doc_keys - data.keys()}"
+        )
+        assert data["filename"] == "factura.pdf"
+        assert data["upload_url"] is None
+
+
+# ── Documented params match what the API actually accepts ─────────────────────
+
+
+class TestDocumentedParamsAccepted:
+    """Verify the documented request bodies are accepted (no 422 validation error)."""
+
+    def test_upload_url_body_shape(self, client):
+        """Documented upload-url body should not cause 422."""
+        ep = _get_doc_endpoint("POST", "/extraction/upload-url")
+        body = _parse_doc_json(ep.request_body)
+        with patch("src.infrastructure.api.extraction.routes.get_storage") as mock_storage:
+            mock_storage.return_value.generate_upload_url.return_value = "https://example.com"
+            resp = client.post("/extraction/upload-url", json=body)
+        assert resp.status_code != 422, f"Documented body caused validation error: {resp.json()}"
+
+    def test_create_token_body_shape(self, client):
+        """Documented create-token body should not cause 422."""
+        ep = _get_doc_endpoint("POST", "/tokens")
+        body = _parse_doc_json(ep.request_body)
+        with (
+            patch("src.infrastructure.api.tokens.routes.generate_api_token") as mock_gen,
+            patch("src.infrastructure.api.tokens.routes.hash_token", return_value="h"),
+            patch("src.infrastructure.api.tokens.routes.ApiTokenRepository") as MockRepo,
+        ):
+            mock_gen.return_value = f"{TOKEN_PREFIX}test"
+            MockRepo.return_value.create.return_value = ApiTokenData(
+                id=TOKEN_UUID, user_id=USER_UUID, name="test"
+            )
+            resp = client.post("/tokens", json=body)
+        assert resp.status_code != 422, f"Documented body caused validation error: {resp.json()}"
+
+    def test_extract_body_shape(self, client):
+        """Documented extract body should not cause 422."""
+        body = {
+            "s3_key": "uploads/abc123-factura.pdf",
+            "filename": "factura.pdf",
+            "extractor_config_id": str(CONFIG_UUID),
+        }
+        with (
+            patch("src.infrastructure.api.extraction.routes.get_storage") as mock_storage,
+            patch("src.infrastructure.api.extraction.routes.ExtractionService") as MockSvc,
+            patch(
+                "src.infrastructure.api.extraction.routes.ExtractorConfigRepository"
+            ) as MockCfg,
+            patch("src.infrastructure.api.extraction.routes.ApiCallRepository"),
+            patch("src.infrastructure.api.extraction.routes.AiUsageLogRepository"),
+            patch("src.infrastructure.api.extraction.routes.QuotaService") as MockQ,
+        ):
+            MockQ.return_value.check_extraction_quota.return_value = None
+            mock_storage.return_value.download.return_value = b"bytes"
+            MockSvc.return_value.extract.return_value = (
+                {}, ApiCallResult("m", True, 1.0), None
+            )
+            MockCfg.return_value.get_by_id.return_value = _make_config()
+            MockCfg.return_value.get_active_versions.return_value = []
+            resp = client.post("/extraction/extract", json=body)
+        assert resp.status_code != 422, f"Documented body caused validation error: {resp.json()}"
+
+    def test_submit_body_shape(self, client):
+        """Documented submit body should not cause 422."""
+        body = {
+            "filename": "factura.pdf",
+            "extracted_fields": {"titular": "Juan Peres", "monto": "$1,500.00"},
+            "final_fields": {"titular": "Juan Perez", "monto": "$1,500.00"},
+            "extractor_config_id": str(CONFIG_UUID),
+        }
+        with patch(
+            "src.infrastructure.api.extraction.routes.ExtractionRepository"
+        ) as MockRepo:
+            MockRepo.return_value.create.return_value = MagicMock(id=LOG_UUID)
+            resp = client.post("/extraction/submit", json=body)
+        assert resp.status_code != 422, f"Documented body caused validation error: {resp.json()}"
+
+
+# ── Full documented flow (as shown on the index page) ─────────────────────────
+
+
+class TestDocumentedFullFlow:
+    """Simulate the exact flow shown in the index page examples:
+    1. List extractors and pick one
+    2. Get upload URL
+    3. (upload to S3 — skipped, external)
+    4. Extract with the chosen extractor_id + s3_key
+    5. Submit corrections with extractor_id
+    """
+
+    def test_full_extraction_flow(self, client):
+        config = _make_config()
+        config2 = _make_config(
+            id=CONFIG_UUID_2,
+            name="Facturas",
+            is_default=False,
+            status="active",
+        )
+        call_result = ApiCallResult(
+            model="claude-haiku-4-5-20251001", success=True, response_time_ms=120.0
+        )
+
+        # ── Step 1: GET /extractors → pick the first active one ──────────
+        with patch(
+            "src.infrastructure.api.extractors.routes.ExtractorConfigRepository"
+        ) as MockRepo:
+            MockRepo.return_value.get_all.return_value = [config, config2]
+            resp = client.get("/extractors")
+
+        assert resp.status_code == 200
+        configs = resp.json()["configs"]
+        assert len(configs) == 2
+        # Pick first active (same logic as documented example)
+        active = next(c for c in configs if c["status"] == "active")
+        extractor_id = active["id"]
+
+        # ── Step 2: POST /extraction/upload-url ──────────────────────────
+        with patch("src.infrastructure.api.extraction.routes.get_storage") as mock_storage:
+            mock_storage.return_value.generate_upload_url.return_value = (
+                "https://s3.example.com/signed-url"
+            )
+            resp = client.post(
+                "/extraction/upload-url",
+                json={"filename": "factura.pdf", "content_type": "application/pdf"},
+            )
+
+        assert resp.status_code == 200
+        upload_data = resp.json()
+        s3_key = upload_data["s3_key"]
+        assert s3_key  # non-empty
+        assert upload_data["upload_url"]  # presigned URL returned
+
+        # ── Step 3: PUT to S3 (external, skip) ───────────────────────────
+
+        # ── Step 4: POST /extraction/extract with extractor_id + s3_key ──
+        with (
+            patch("src.infrastructure.api.extraction.routes.get_storage") as mock_storage,
+            patch("src.infrastructure.api.extraction.routes.ExtractionService") as MockSvc,
+            patch(
+                "src.infrastructure.api.extraction.routes.ExtractorConfigRepository"
+            ) as MockCfgRepo,
+            patch("src.infrastructure.api.extraction.routes.ApiCallRepository"),
+            patch("src.infrastructure.api.extraction.routes.AiUsageLogRepository"),
+            patch("src.infrastructure.api.extraction.routes.QuotaService") as MockQuota,
+        ):
+            MockQuota.return_value.check_extraction_quota.return_value = None
+            mock_storage.return_value.download.return_value = b"fake-pdf"
+            MockSvc.return_value.extract.return_value = (
+                {"titular": "Juan Peres", "monto": "$1,500.00"},
+                call_result,
+                None,
+            )
+            MockCfgRepo.return_value.get_by_id.return_value = config
+            MockCfgRepo.return_value.get_active_versions.return_value = []
+
+            resp = client.post(
+                "/extraction/extract",
+                json={
+                    "s3_key": s3_key,
+                    "filename": "factura.pdf",
+                    "extractor_config_id": extractor_id,
+                },
+            )
+
+        assert resp.status_code == 200
+        extract_data = resp.json()
+        fields = extract_data["fields"]
+        assert "titular" in fields
+        assert "monto" in fields
+        assert extract_data["extractor_config_id"] is not None
+        assert extract_data["extractor_config_name"] == config.name
+
+        # ── Step 5: POST /extraction/submit with corrections ─────────────
+        corrected_fields = {**fields, "titular": "Juan Perez"}
+
+        with patch(
+            "src.infrastructure.api.extraction.routes.ExtractionRepository"
+        ) as MockRepo:
+            MockRepo.return_value.create.return_value = MagicMock(id=LOG_UUID)
+            resp = client.post(
+                "/extraction/submit",
+                json={
+                    "filename": "factura.pdf",
+                    "extracted_fields": fields,
+                    "final_fields": corrected_fields,
+                    "extractor_config_id": extractor_id,
+                },
+            )
+
+        assert resp.status_code == 200
+        submit_data = resp.json()
+        assert submit_data["message"]
+        assert submit_data["id"]
+
+    def test_flow_without_extractor_id_uses_default(self, client):
+        """Extract without extractor_config_id should still work (uses default)."""
+        default_config = _make_config(is_default=True)
+        call_result = ApiCallResult(
+            model="claude-haiku-4-5-20251001", success=True, response_time_ms=100.0
+        )
+
+        with (
+            patch("src.infrastructure.api.extraction.routes.get_storage") as mock_storage,
+            patch("src.infrastructure.api.extraction.routes.ExtractionService") as MockSvc,
+            patch(
+                "src.infrastructure.api.extraction.routes.ExtractorConfigRepository"
+            ) as MockCfgRepo,
+            patch("src.infrastructure.api.extraction.routes.ApiCallRepository"),
+            patch("src.infrastructure.api.extraction.routes.AiUsageLogRepository"),
+            patch("src.infrastructure.api.extraction.routes.QuotaService") as MockQuota,
+        ):
+            MockQuota.return_value.check_extraction_quota.return_value = None
+            mock_storage.return_value.download.return_value = b"bytes"
+            MockSvc.return_value.extract.return_value = (
+                {"titular": "Test"}, call_result, None
+            )
+            MockCfgRepo.return_value.get_by_id.return_value = None
+            MockCfgRepo.return_value.get_default.return_value = default_config
+
+            resp = client.post(
+                "/extraction/extract",
+                json={
+                    "s3_key": "uploads/test.pdf",
+                    "filename": "test.pdf",
+                    # No extractor_config_id — should use default
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["fields"]["titular"] == "Test"
+        assert data["extractor_config_name"] == default_config.name

--- a/backend/src/tests/test_docs_examples.py
+++ b/backend/src/tests/test_docs_examples.py
@@ -32,7 +32,7 @@ from src.tests.conftest import (
 def _parse_doc_json(text: str) -> dict | list:
     """Parse a documentation JSON body, replacing placeholders."""
     text = re.sub(r'"([^"]*)\.\.\."', r'"\1placeholder"', text)
-    text = re.sub(r'\{\s*\.\.\.\s*\}', '{}', text)
+    text = re.sub(r"\{\s*\.\.\.\s*\}", "{}", text)
     text = text.replace("...", '"__placeholder__"')
     return json.loads(text)
 
@@ -257,8 +257,9 @@ class TestExtractionExamples:
         }
 
         config = _make_config()
-        call_result = ApiCallResult(model="claude-haiku-4-5-20251001", success=True,
-                                    response_time_ms=150.0)
+        call_result = ApiCallResult(
+            model="claude-haiku-4-5-20251001", success=True, response_time_ms=150.0
+        )
 
         with (
             patch("src.infrastructure.api.extraction.routes.get_storage") as mock_storage,
@@ -302,9 +303,7 @@ class TestExtractionExamples:
             "extractor_config_id": str(CONFIG_UUID),
         }
 
-        with patch(
-            "src.infrastructure.api.extraction.routes.ExtractionRepository"
-        ) as MockRepo:
+        with patch("src.infrastructure.api.extraction.routes.ExtractionRepository") as MockRepo:
             MockRepo.return_value.create.return_value = MagicMock(id=LOG_UUID)
             resp = client.post("/extraction/submit", json=request_body)
 
@@ -394,18 +393,14 @@ class TestDocumentedParamsAccepted:
         with (
             patch("src.infrastructure.api.extraction.routes.get_storage") as mock_storage,
             patch("src.infrastructure.api.extraction.routes.ExtractionService") as MockSvc,
-            patch(
-                "src.infrastructure.api.extraction.routes.ExtractorConfigRepository"
-            ) as MockCfg,
+            patch("src.infrastructure.api.extraction.routes.ExtractorConfigRepository") as MockCfg,
             patch("src.infrastructure.api.extraction.routes.ApiCallRepository"),
             patch("src.infrastructure.api.extraction.routes.AiUsageLogRepository"),
             patch("src.infrastructure.api.extraction.routes.QuotaService") as MockQ,
         ):
             MockQ.return_value.check_extraction_quota.return_value = None
             mock_storage.return_value.download.return_value = b"bytes"
-            MockSvc.return_value.extract.return_value = (
-                {}, ApiCallResult("m", True, 1.0), None
-            )
+            MockSvc.return_value.extract.return_value = ({}, ApiCallResult("m", True, 1.0), None)
             MockCfg.return_value.get_by_id.return_value = _make_config()
             MockCfg.return_value.get_active_versions.return_value = []
             resp = client.post("/extraction/extract", json=body)
@@ -419,9 +414,7 @@ class TestDocumentedParamsAccepted:
             "final_fields": {"titular": "Juan Perez", "monto": "$1,500.00"},
             "extractor_config_id": str(CONFIG_UUID),
         }
-        with patch(
-            "src.infrastructure.api.extraction.routes.ExtractionRepository"
-        ) as MockRepo:
+        with patch("src.infrastructure.api.extraction.routes.ExtractionRepository") as MockRepo:
             MockRepo.return_value.create.return_value = MagicMock(id=LOG_UUID)
             resp = client.post("/extraction/submit", json=body)
         assert resp.status_code != 422, f"Documented body caused validation error: {resp.json()}"
@@ -524,9 +517,7 @@ class TestDocumentedFullFlow:
         # ── Step 5: POST /extraction/submit with corrections ─────────────
         corrected_fields = {**fields, "titular": "Juan Perez"}
 
-        with patch(
-            "src.infrastructure.api.extraction.routes.ExtractionRepository"
-        ) as MockRepo:
+        with patch("src.infrastructure.api.extraction.routes.ExtractionRepository") as MockRepo:
             MockRepo.return_value.create.return_value = MagicMock(id=LOG_UUID)
             resp = client.post(
                 "/extraction/submit",
@@ -562,9 +553,7 @@ class TestDocumentedFullFlow:
         ):
             MockQuota.return_value.check_extraction_quota.return_value = None
             mock_storage.return_value.download.return_value = b"bytes"
-            MockSvc.return_value.extract.return_value = (
-                {"titular": "Test"}, call_result, None
-            )
+            MockSvc.return_value.extract.return_value = ({"titular": "Test"}, call_result, None)
             MockCfgRepo.return_value.get_by_id.return_value = None
             MockCfgRepo.return_value.get_default.return_value = default_config
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -402,6 +402,7 @@ dependencies = [
     { name = "boto3" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "jinja2" },
     { name = "langchain-anthropic" },
     { name = "pdf2image" },
     { name = "pdfplumber" },
@@ -435,6 +436,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "fastapi", specifier = ">=0.104.0" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "langchain-anthropic", specifier = ">=0.3.0" },
     { name = "pdf2image", specifier = ">=1.16.0" },
     { name = "pdfplumber", specifier = ">=0.10.0" },
@@ -610,6 +612,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace Swagger UI at `/api/docs` with a custom documentation site using Jinja2 templates
- Welcome page with quick start guide, SVG flow diagram, and full end-to-end examples in Python and JavaScript (including extractor selection step)
- Per-endpoint pages with description, parameter tables, tabbed code examples (cURL/Python/JS), and prev/next navigation
- Syntax highlighting via Prism.js with copy-to-clipboard on all code blocks
- API base URL auto-detected from request host (works in dev and prod without config)
- 42 new tests: docs ↔ whitelist sync, OpenAPI param matching, JSON validity, full flow simulation

## Test plan
- [x] `ruff check .` passes
- [x] 142 tests pass (42 new for docs)
- [x] Verified pages render at `http://localhost:8000/api/docs`
- [ ] Verify on prod after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)