### PR TITLE
Multi-provider extractor, DocumentExtractor rename, array fields UI

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "alembic>=1.13.0",
     "PyJWT>=2.8.0",
     "langchain-anthropic>=0.3.0",
+    "langchain-openai>=0.3.0",
     "cryptography>=46.0.5",
     "jinja2>=3.1.6",
 ]

--- a/backend/scripts/run_experiment.py
+++ b/backend/scripts/run_experiment.py
@@ -67,10 +67,10 @@ def digit_difference(pred: str, actual: str) -> int | None:
 # Extraction runner
 # ---------------------------------------------------------------------------
 def run_extraction(pdf_files: list[Path]) -> pd.DataFrame:
-    """Run StatementExtractor on a list of PDFs and return results DataFrame."""
-    from src.infrastructure.extractors.statement_extractor import StatementExtractor
+    """Run DocumentExtractor on a list of PDFs and return results DataFrame."""
+    from src.infrastructure.extractors.document_extractor import DocumentExtractor
 
-    extractor = StatementExtractor()
+    extractor = DocumentExtractor()
 
     results = []
     total = len(pdf_files)

--- a/backend/scripts/run_extraction.py
+++ b/backend/scripts/run_extraction.py
@@ -40,11 +40,11 @@ def main():
 
     experiment = ExperimentRunner(experiment_name="bank_extraction", output_dir=output_dir)
 
-    print("\nRunning StatementExtractor extraction...")
-    from src.infrastructure.extractors.statement_extractor import StatementExtractor
+    print("\nRunning DocumentExtractor extraction...")
+    from src.infrastructure.extractors.document_extractor import DocumentExtractor
 
-    statement_extractor = StatementExtractor()
-    experiment.run_experiment(statement_extractor, pdf_files, "statement_extractor")
+    extractor = DocumentExtractor()
+    experiment.run_experiment(extractor, pdf_files, "document_extractor")
 
     print("\n✓ Extraction complete!")
 

--- a/backend/src/domain/services/extraction.py
+++ b/backend/src/domain/services/extraction.py
@@ -6,9 +6,10 @@ from src.domain.constants import UNKNOWN_ACCOUNT, UNKNOWN_BANK, UNKNOWN_OWNER
 from src.domain.entities import ApiCallResult, ExtractionError, ExtractorConfigData
 from src.domain.schemas import BankAccount
 from src.domain.validators import validate_clabe
-from src.infrastructure.extractors.statement_extractor import (
+from src.infrastructure.extractors.document_extractor import (
     SUPPORTED_EXTENSIONS,
-    StatementExtractor,
+    DocumentExtractor,
+    retry_bank_statement_clabe,
 )
 
 ALLOWED_EXTENSIONS = SUPPORTED_EXTENSIONS
@@ -55,8 +56,8 @@ def apply_bank_statement_postprocessing(raw: dict) -> dict:
     }
 
 
-def _create_extractor(config: ExtractorConfigData) -> StatementExtractor:
-    return StatementExtractor(
+def _create_extractor(config: ExtractorConfigData) -> DocumentExtractor:
+    return DocumentExtractor(
         prompt=config.prompt,
         model=config.model,
         output_schema=config.output_schema,
@@ -69,6 +70,7 @@ class ExtractionService:
         file_bytes: bytes,
         filename: str,
         config: ExtractorConfigData | None = None,
+        image_url: str | None = None,
     ) -> tuple[dict, ApiCallResult, ExtractorConfigData | None]:
         if not filename:
             raise ValueError("No se proporcionó un archivo")
@@ -89,11 +91,11 @@ class ExtractionService:
             if config:
                 extractor = _create_extractor(config)
             else:
-                extractor = StatementExtractor()
+                extractor = DocumentExtractor()
 
             start = time.monotonic()
             try:
-                raw_result = extractor.extract_file(tmp_file_path)
+                raw_result = extractor.extract_file(tmp_file_path, image_url=image_url)
             except ValueError as e:
                 elapsed_ms = round((time.monotonic() - start) * 1000, 1)
                 call_result = ApiCallResult(
@@ -117,9 +119,12 @@ class ExtractionService:
 
             elapsed_ms = round((time.monotonic() - start) * 1000, 1)
 
-            # Apply bank statement postprocessing for default extractor
+            # Apply bank-statement-specific logic for default extractor
             is_default = config is None or config.is_default
             if is_default:
+                raw_result = retry_bank_statement_clabe(
+                    extractor, tmp_file_path, raw_result
+                )
                 try:
                     raw_result = apply_bank_statement_postprocessing(raw_result)
                 except ValueError as e:

--- a/backend/src/domain/services/extraction.py
+++ b/backend/src/domain/services/extraction.py
@@ -122,9 +122,7 @@ class ExtractionService:
             # Apply bank-statement-specific logic for default extractor
             is_default = config is None or config.is_default
             if is_default:
-                raw_result = retry_bank_statement_clabe(
-                    extractor, tmp_file_path, raw_result
-                )
+                raw_result = retry_bank_statement_clabe(extractor, tmp_file_path, raw_result)
                 try:
                     raw_result = apply_bank_statement_postprocessing(raw_result)
                 except ValueError as e:

--- a/backend/src/infrastructure/api/extraction/routes.py
+++ b/backend/src/infrastructure/api/extraction/routes.py
@@ -138,9 +138,12 @@ async def extract_from_file(request: ExtractRequest, db: DbDep, user: UserDep):
     try:
         storage = get_storage()
         file_bytes = storage.download(request.s3_key)
+        download_url = storage.generate_download_url(request.s3_key)
 
         service = ExtractionService()
-        result, call_result, _ = service.extract(file_bytes, request.filename, config=config_data)
+        result, call_result, _ = service.extract(
+            file_bytes, request.filename, config=config_data, image_url=download_url
+        )
 
         api_repo.create(
             call_result,

--- a/backend/src/infrastructure/api/extractors/routes.py
+++ b/backend/src/infrastructure/api/extractors/routes.py
@@ -37,9 +37,9 @@ from src.infrastructure.api.extraction.dtos import (
 )
 from src.infrastructure.auth import UserDep
 from src.infrastructure.database import get_db
-from src.infrastructure.extractors.statement_extractor import (
+from src.infrastructure.extractors.document_extractor import (
     SUPPORTED_EXTENSIONS,
-    StatementExtractor,
+    DocumentExtractor,
 )
 from src.infrastructure.repository import (
     AiUsageLogRepository,
@@ -188,14 +188,15 @@ async def test_extract(request: TestExtractRequest, db: DbDep, user: UserDep):
     try:
         storage = get_storage()
         file_bytes = storage.download(request.s3_key)
+        download_url = storage.generate_download_url(request.s3_key)
 
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
             tmp.write(file_bytes)
             tmp_path = Path(tmp.name)
 
-        extractor = StatementExtractor(prompt=prompt, model=model, output_schema=output_schema)
+        extractor = DocumentExtractor(prompt=prompt, model=model, output_schema=output_schema)
         start = time.monotonic()
-        result = extractor.extract_file(tmp_path)
+        result = extractor.extract_file(tmp_path, image_url=download_url)
         elapsed_ms = round((time.monotonic() - start) * 1000, 1)
 
         log = test_log_repo.create(

--- a/backend/src/infrastructure/extractors/document_extractor.py
+++ b/backend/src/infrastructure/extractors/document_extractor.py
@@ -4,8 +4,6 @@ import os
 import re
 from pathlib import Path
 
-import anthropic
-from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage
 from PIL import Image
 
@@ -59,6 +57,7 @@ ORIENTATION_CHECK_PROMPT = (
 )
 
 ORIENTATION_SCHEMA = {
+    "title": "orientation_check",
     "type": "object",
     "properties": {
         "text_direction": {
@@ -94,7 +93,65 @@ DIRECTION_TO_ROTATION = {
 }
 
 
-class StatementExtractor:
+PROVIDERS = {
+    "anthropic": {
+        "prefixes": ("claude-",),
+        "env_key": "ANTHROPIC_API_KEY",
+        "native_pdf": True,
+        "llm_factory": lambda model, api_key, max_tokens: _import_anthropic()(
+            model=model, api_key=api_key, max_tokens=max_tokens, temperature=0
+        ),
+    },
+    "openai": {
+        "prefixes": ("gpt-", "o1", "o3", "o4"),
+        "env_key": "OPENAI_KEY",
+        "native_pdf": False,
+        "llm_factory": lambda model, api_key, max_tokens: _import_openai()(
+            model=model, api_key=api_key, max_tokens=max_tokens, temperature=0
+        ),
+    },
+    "google": {
+        "prefixes": ("gemini-",),
+        "env_key": "GOOGLE_API_KEY",
+        "native_pdf": False,
+        "llm_factory": lambda model, api_key, max_tokens: _import_google()(
+            model=model, api_key=api_key, max_tokens=max_tokens, temperature=0
+        ),
+    },
+}
+
+
+def _import_anthropic():
+    from langchain_anthropic import ChatAnthropic
+
+    return ChatAnthropic
+
+
+def _import_openai():
+    from langchain_openai import ChatOpenAI
+
+    return ChatOpenAI
+
+
+def _import_google():
+    from langchain_google_genai import ChatGoogleGenerativeAI
+
+    return ChatGoogleGenerativeAI
+
+
+def _resolve_provider(model: str) -> dict:
+    for provider in PROVIDERS.values():
+        if model.startswith(provider["prefixes"]):
+            return provider
+    return PROVIDERS["anthropic"]
+
+
+def _create_llm(model: str, api_key: str, max_tokens: int):
+    provider = _resolve_provider(model)
+    return provider["llm_factory"](model, api_key, max_tokens)
+
+
+class DocumentExtractor:
     def __init__(
         self,
         prompt: str = EXTRACTION_PROMPT,
@@ -103,17 +160,16 @@ class StatementExtractor:
         api_key: str | None = None,
         max_tokens: int = 1024,
     ):
-        self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+        self.provider = _resolve_provider(model)
+        if api_key:
+            self.api_key = api_key
+        else:
+            self.api_key = os.environ.get(self.provider["env_key"], "")
         self.model_name = model
         self.max_tokens = max_tokens
         self.prompt = prompt
         self.output_schema = output_schema
-        self.llm = ChatAnthropic(
-            model=model,
-            api_key=self.api_key,
-            max_tokens=max_tokens,
-            temperature=0,
-        )
+        self.llm = _create_llm(model, self.api_key, max_tokens)
         if output_schema:
             if isinstance(output_schema, dict) and "title" not in output_schema:
                 output_schema = {"title": "extraction_output", **output_schema}
@@ -122,6 +178,28 @@ class StatementExtractor:
             from src.domain.schemas import ExtractionOutput
 
             self.structured_llm = self.llm.with_structured_output(ExtractionOutput)
+
+    def _image_content(self, *, b64: str | None = None, url: str | None = None) -> dict:
+        """Build the image content block in the correct format for the current provider."""
+        if url and url.startswith("https://"):
+            if self.provider["native_pdf"]:
+                return {
+                    "type": "image",
+                    "source": {"type": "url", "url": url},
+                }
+            return {"type": "image_url", "image_url": {"url": url}}
+
+        if b64 is None:
+            raise ValueError("Se requiere b64 o url")
+
+        if self.provider["native_pdf"]:
+            # Anthropic format
+            return {
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/jpeg", "data": b64},
+            }
+        # OpenAI / others format
+        return {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}}
 
     def _image_to_base64(self, image: Image.Image) -> str:
         max_dimension = 2048
@@ -137,38 +215,17 @@ class StatementExtractor:
     def _check_orientation(self, image_b64: str) -> int:
         """Ask the model to detect text orientation. Returns CW degrees to correct."""
         try:
-            client = anthropic.Anthropic(api_key=self.api_key)
-            response = client.messages.create(
-                model=self.model_name,
-                max_tokens=256,
-                temperature=0,
-                tools=[
-                    {
-                        "name": "orientation_check",
-                        "description": "Report the orientation of the document text",
-                        "input_schema": ORIENTATION_SCHEMA,
-                    }
-                ],
-                tool_choice={"type": "tool", "name": "orientation_check"},
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "image",
-                                "source": {
-                                    "type": "base64",
-                                    "media_type": "image/jpeg",
-                                    "data": image_b64,
-                                },
-                            },
-                            {"type": "text", "text": ORIENTATION_CHECK_PROMPT},
-                        ],
-                    }
-                ],
-            )
-            tool_block = next(b for b in response.content if b.type == "tool_use")
-            direction = tool_block.input.get("text_direction", "normal")
+            orientation_llm = _create_llm(self.model_name, self.api_key, 256)
+            structured = orientation_llm.with_structured_output(ORIENTATION_SCHEMA)
+            content = [
+                self._image_content(b64=image_b64),
+                {"type": "text", "text": ORIENTATION_CHECK_PROMPT},
+            ]
+            message = HumanMessage(content=content)
+            result = structured.invoke([message])
+            if hasattr(result, "model_dump"):
+                result = result.model_dump()
+            direction = result.get("text_direction", "normal")
             rotation = DIRECTION_TO_ROTATION.get(direction, 0)
             logger.info("Orientation check: %s → rotation %d°", direction, rotation)
             return rotation
@@ -196,14 +253,10 @@ class StatementExtractor:
     def _pdf_to_image(self, pdf_path: Path) -> Image.Image | None:
         """Convert first page of PDF to PIL Image for orientation check."""
         try:
-            import fitz  # PyMuPDF
+            from pdf2image import convert_from_path
 
-            doc = fitz.open(pdf_path)
-            page = doc[0]
-            pix = page.get_pixmap(dpi=200)
-            img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
-            doc.close()
-            return img
+            images = convert_from_path(str(pdf_path), first_page=1, last_page=1, dpi=200)
+            return images[0] if images else None
         except Exception as e:
             logger.warning("PDF to image conversion failed: %s", e)
             return None
@@ -223,6 +276,15 @@ class StatementExtractor:
                 img_b64 = self._image_to_base64(img)
                 return self._extract_with_vision([img_b64])
 
+        # Non-Anthropic models don't support native PDF — use vision
+        if not self.provider["native_pdf"]:
+            if img is None:
+                img = self._pdf_to_image(pdf_path)
+            if img is None:
+                raise ValueError("No se pudo convertir el PDF a imagen")
+            img_b64 = self._image_to_base64(img)
+            return self._extract_with_vision([img_b64])
+
         pdf_data = pdf_path.read_bytes()
         pdf_base64 = base64.b64encode(pdf_data).decode("utf-8")
         content = [
@@ -241,18 +303,19 @@ class StatementExtractor:
         logger.info("Extraction result: %s", result)
         return result
 
-    def _extract_with_vision(self, base64_images: list[str]) -> dict:
+    def _extract_with_vision(
+        self, base64_images: list[str] | None = None, *, image_url: str | None = None
+    ) -> dict:
         logger.info("=== Vision extraction ===")
         logger.info("Model: %s, prompt length: %d", self.model_name, len(self.prompt))
-        content = [
-            {
-                "type": "image",
-                "source_type": "base64",
-                "data": base64_images[0],
-                "mime_type": "image/jpeg",
-            },
-            {"type": "text", "text": self.prompt},
-        ]
+        if image_url:
+            logger.info("Using direct URL (no base64 encoding)")
+            img_block = self._image_content(url=image_url)
+        elif base64_images:
+            img_block = self._image_content(b64=base64_images[0])
+        else:
+            raise ValueError("Se requiere base64_images o image_url")
+        content = [img_block, {"type": "text", "text": self.prompt}]
         message = HumanMessage(content=content)
         result = self.structured_llm.invoke([message])
         if hasattr(result, "model_dump"):
@@ -260,65 +323,77 @@ class StatementExtractor:
         logger.info("Extraction result: %s", result)
         return result
 
-    def _needs_clabe_retry(self, result: dict) -> bool:
-        """Check if the CLABE needs a retry (not 18 digits and not default)."""
-        clabe = str(result.get("account_number", "000000000000000000"))
-        digits = re.sub(r"[^\d]", "", clabe)
-        if digits == "0" * 18:
-            return False
-        return len(digits) != 18
-
-    def extract_file(self, file_path: Path) -> dict:
+    def extract_file(self, file_path: Path, *, image_url: str | None = None) -> dict:
         suffix = file_path.suffix.lower()
         if suffix not in SUPPORTED_EXTENSIONS:
             raise ValueError(f"Tipo de archivo no soportado: {suffix}")
 
         if suffix in PDF_EXTENSIONS:
-            result = self._extract_with_pdf(file_path)
+            return self._extract_with_pdf(file_path)
+        elif image_url and image_url.startswith("https://"):
+            return self._extract_with_vision(image_url=image_url)
         else:
             base64_images = self._load_image_file(file_path)
             if not base64_images:
                 raise ValueError("No se pudo procesar el archivo")
-            result = self._extract_with_vision(base64_images)
+            return self._extract_with_vision(base64_images)
 
-        # Retry with reinforced prompt if CLABE is not 18 digits
-        if self._needs_clabe_retry(result):
-            bad_clabe = result.get("account_number", "")
-            logger.info("CLABE '%s' is not 18 digits, retrying...", bad_clabe)
-            original_prompt = self.prompt
-            self.prompt = self.prompt + "\n\n" + CLABE_RETRY_PROMPT
-            try:
-                if suffix in PDF_EXTENSIONS:
-                    retry_result = self._extract_with_pdf(file_path)
-                else:
-                    retry_result = self._extract_with_vision(base64_images)
-                retry_clabe = str(retry_result.get("account_number", ""))
-                retry_digits = re.sub(r"[^\d]", "", retry_clabe)
-                if len(retry_digits) == 18 and retry_digits != "0" * 18:
-                    logger.info("Retry fixed CLABE: %s", retry_digits)
-                    return retry_result
-                logger.info("Retry did not improve CLABE, keeping original")
-            except Exception as e:
-                logger.warning("Retry failed: %s", e)
-            finally:
-                self.prompt = original_prompt
 
-            # If prompt retry didn't help and it's a PDF, try with 90° rotation
-            if suffix in PDF_EXTENSIONS and self._needs_clabe_retry(result):
-                logger.info("Attempting rotation retry for PDF...")
-                img = self._pdf_to_image(file_path)
-                if img is not None:
-                    rotated = img.rotate(-90, expand=True)
-                    img_b64 = self._image_to_base64(rotated)
-                    try:
-                        rot_result = self._extract_with_vision([img_b64])
-                        rot_clabe = str(rot_result.get("account_number", ""))
-                        rot_digits = re.sub(r"[^\d]", "", rot_clabe)
-                        if len(rot_digits) == 18 and rot_digits != "0" * 18:
-                            logger.info("Rotation retry fixed CLABE: %s", rot_digits)
-                            return rot_result
-                        logger.info("Rotation retry did not improve CLABE")
-                    except Exception as e:
-                        logger.warning("Rotation retry failed: %s", e)
+def _needs_clabe_retry(result: dict) -> bool:
+    """Check if the CLABE needs a retry (not 18 digits and not default)."""
+    clabe = str(result.get("account_number", "000000000000000000"))
+    digits = re.sub(r"[^\d]", "", clabe)
+    if digits == "0" * 18:
+        return False
+    return len(digits) != 18
 
+
+def retry_bank_statement_clabe(
+    extractor: DocumentExtractor, file_path: Path, result: dict
+) -> dict:
+    """Retry extraction if CLABE is not 18 digits. Bank-statement-specific."""
+    if not _needs_clabe_retry(result):
         return result
+
+    suffix = file_path.suffix.lower()
+    bad_clabe = result.get("account_number", "")
+    logger.info("CLABE '%s' is not 18 digits, retrying...", bad_clabe)
+
+    # Stage 1: retry with reinforced prompt
+    original_prompt = extractor.prompt
+    extractor.prompt = extractor.prompt + "\n\n" + CLABE_RETRY_PROMPT
+    try:
+        if suffix in PDF_EXTENSIONS:
+            retry_result = extractor._extract_with_pdf(file_path)
+        else:
+            retry_result = extractor._extract_with_vision()
+        retry_clabe = str(retry_result.get("account_number", ""))
+        retry_digits = re.sub(r"[^\d]", "", retry_clabe)
+        if len(retry_digits) == 18 and retry_digits != "0" * 18:
+            logger.info("Retry fixed CLABE: %s", retry_digits)
+            return retry_result
+        logger.info("Retry did not improve CLABE, keeping original")
+    except Exception as e:
+        logger.warning("Retry failed: %s", e)
+    finally:
+        extractor.prompt = original_prompt
+
+    # Stage 2: try with 90° rotation (PDF only)
+    if suffix in PDF_EXTENSIONS and _needs_clabe_retry(result):
+        logger.info("Attempting rotation retry for PDF...")
+        img = extractor._pdf_to_image(file_path)
+        if img is not None:
+            rotated = img.rotate(-90, expand=True)
+            img_b64 = extractor._image_to_base64(rotated)
+            try:
+                rot_result = extractor._extract_with_vision([img_b64])
+                rot_clabe = str(rot_result.get("account_number", ""))
+                rot_digits = re.sub(r"[^\d]", "", rot_clabe)
+                if len(rot_digits) == 18 and rot_digits != "0" * 18:
+                    logger.info("Rotation retry fixed CLABE: %s", rot_digits)
+                    return rot_result
+                logger.info("Rotation retry did not improve CLABE")
+            except Exception as e:
+                logger.warning("Rotation retry failed: %s", e)
+
+    return result

--- a/backend/src/infrastructure/extractors/document_extractor.py
+++ b/backend/src/infrastructure/extractors/document_extractor.py
@@ -348,9 +348,7 @@ def _needs_clabe_retry(result: dict) -> bool:
     return len(digits) != 18
 
 
-def retry_bank_statement_clabe(
-    extractor: DocumentExtractor, file_path: Path, result: dict
-) -> dict:
+def retry_bank_statement_clabe(extractor: DocumentExtractor, file_path: Path, result: dict) -> dict:
     """Retry extraction if CLABE is not 18 digits. Bank-statement-specific."""
     if not _needs_clabe_retry(result):
         return result

--- a/backend/src/infrastructure/storage.py
+++ b/backend/src/infrastructure/storage.py
@@ -32,6 +32,10 @@ class StorageBackend(ABC):
     @abstractmethod
     def download(self, key: str) -> bytes: ...
 
+    def generate_download_url(self, key: str) -> str | None:
+        """Return a presigned GET URL, or None if not supported."""
+        return None
+
     def configure_cors(self, allowed_origins: list[str]) -> None:
         """Configure CORS on the storage bucket. No-op by default."""
 
@@ -81,6 +85,13 @@ class S3Storage(StorageBackend):
     def download(self, key: str) -> bytes:
         response = self._client.get_object(Bucket=self._bucket, Key=key)
         return response["Body"].read()
+
+    def generate_download_url(self, key: str) -> str | None:
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self._bucket, "Key": key},
+            ExpiresIn=PRESIGNED_URL_EXPIRY,
+        )
 
     def configure_cors(self, allowed_origins: list[str]) -> None:
         cors_config = {

--- a/backend/src/tests/test_multi_provider.py
+++ b/backend/src/tests/test_multi_provider.py
@@ -216,9 +216,7 @@ class TestExtractFileWithImageUrl:
         ext = DocumentExtractor(model="claude-haiku-4-5-20251001", api_key="fake")
 
         with patch.object(ext, "_extract_with_pdf", return_value={"field": "value"}) as mock_pdf:
-            ext.extract_file(
-                Path("/fake/file.pdf"), image_url="https://s3.example.com/file.pdf"
-            )
+            ext.extract_file(Path("/fake/file.pdf"), image_url="https://s3.example.com/file.pdf")
 
         mock_pdf.assert_called_once()
 

--- a/backend/src/tests/test_multi_provider.py
+++ b/backend/src/tests/test_multi_provider.py
@@ -1,0 +1,231 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.infrastructure.extractors.document_extractor import (
+    PROVIDERS,
+    DocumentExtractor,
+    _resolve_provider,
+)
+
+
+class TestResolveProvider:
+    @pytest.mark.parametrize(
+        "model,expected_key",
+        [
+            ("claude-haiku-4-5-20251001", "ANTHROPIC_API_KEY"),
+            ("claude-sonnet-4-6-20260326", "ANTHROPIC_API_KEY"),
+            ("gpt-4o-mini", "OPENAI_KEY"),
+            ("gpt-4o", "OPENAI_KEY"),
+            ("o4-mini", "OPENAI_KEY"),
+            ("o1", "OPENAI_KEY"),
+            ("o3", "OPENAI_KEY"),
+            ("gemini-2.0-flash", "GOOGLE_API_KEY"),
+            ("gemini-1.5-pro", "GOOGLE_API_KEY"),
+        ],
+    )
+    def test_resolves_correct_provider(self, model, expected_key):
+        provider = _resolve_provider(model)
+        assert provider["env_key"] == expected_key
+
+    def test_unknown_model_defaults_to_anthropic(self):
+        provider = _resolve_provider("some-unknown-model")
+        assert provider["env_key"] == "ANTHROPIC_API_KEY"
+
+    def test_anthropic_supports_native_pdf(self):
+        assert PROVIDERS["anthropic"]["native_pdf"] is True
+
+    @pytest.mark.parametrize("name", ["openai", "google"])
+    def test_non_anthropic_no_native_pdf(self, name):
+        assert PROVIDERS[name]["native_pdf"] is False
+
+
+class TestDocumentExtractorInit:
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_anthropic_uses_anthropic_key(self, mock_create):
+        mock_create.return_value = MagicMock()
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant-test"}):
+            ext = DocumentExtractor(model="claude-haiku-4-5-20251001")
+        assert ext.api_key == "sk-ant-test"
+
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_openai_uses_openai_key(self, mock_create):
+        mock_create.return_value = MagicMock()
+        with patch.dict("os.environ", {"OPENAI_KEY": "sk-openai-test"}):
+            ext = DocumentExtractor(model="gpt-4o-mini")
+        assert ext.api_key == "sk-openai-test"
+
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_google_uses_google_key(self, mock_create):
+        mock_create.return_value = MagicMock()
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": "goog-test"}):
+            ext = DocumentExtractor(model="gemini-2.0-flash")
+        assert ext.api_key == "goog-test"
+
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_explicit_api_key_overrides_env(self, mock_create):
+        mock_create.return_value = MagicMock()
+        ext = DocumentExtractor(model="gpt-4o-mini", api_key="explicit-key")
+        assert ext.api_key == "explicit-key"
+
+
+class TestExtractWithVision:
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_anthropic_uses_native_base64_format(self, mock_create):
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output.return_value.invoke.return_value = {"field": "value"}
+        mock_create.return_value = mock_llm
+
+        ext = DocumentExtractor(model="claude-haiku-4-5-20251001", api_key="fake")
+        result = ext._extract_with_vision(["abc123base64data"])
+
+        call_args = ext.structured_llm.invoke.call_args[0][0][0]
+        img_block = call_args.content[0]
+        assert img_block["type"] == "image"
+        assert img_block["source"]["type"] == "base64"
+        assert img_block["source"]["data"] == "abc123base64data"
+        assert result == {"field": "value"}
+
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_openai_uses_data_uri_format(self, mock_create):
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output.return_value.invoke.return_value = {"field": "value"}
+        mock_create.return_value = mock_llm
+
+        ext = DocumentExtractor(model="gpt-4o-mini", api_key="fake")
+        ext._extract_with_vision(["abc123base64data"])
+
+        call_args = ext.structured_llm.invoke.call_args[0][0][0]
+        img_block = call_args.content[0]
+        assert img_block["type"] == "image_url"
+        assert img_block["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_uses_url_when_provided(self, mock_create):
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output.return_value.invoke.return_value = {"field": "value"}
+        mock_create.return_value = mock_llm
+
+        ext = DocumentExtractor(model="gpt-4o-mini", api_key="fake")
+        result = ext._extract_with_vision(image_url="https://s3.example.com/file.jpg")
+
+        call_args = ext.structured_llm.invoke.call_args[0][0][0]
+        img_block = call_args.content[0]
+        assert img_block["image_url"]["url"] == "https://s3.example.com/file.jpg"
+        assert result == {"field": "value"}
+
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_raises_when_no_image_source(self, mock_create):
+        mock_create.return_value = MagicMock()
+        ext = DocumentExtractor(model="gpt-4o-mini", api_key="fake")
+        with pytest.raises(ValueError, match="Se requiere"):
+            ext._extract_with_vision()
+
+
+class TestPdfFallbackForNonAnthropicProviders:
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_openai_converts_pdf_to_image(self, mock_create):
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output.return_value.invoke.return_value = {"field": "value"}
+        mock_create.return_value = mock_llm
+
+        ext = DocumentExtractor(model="gpt-4o-mini", api_key="fake")
+        fake_img = MagicMock()
+        fake_img.width = 100
+        fake_img.height = 100
+        fake_img.rotate.return_value = fake_img
+        fake_img.save = MagicMock(side_effect=lambda buf, **kw: buf.write(b"\xff\xd8fake"))
+
+        with patch.object(ext, "_pdf_to_image", return_value=fake_img) as mock_pdf:
+            with patch.object(ext, "_check_orientation", return_value=0):
+                result = ext._extract_with_pdf(Path("/fake/file.pdf"))
+
+        mock_pdf.assert_called()
+        assert result == {"field": "value"}
+
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_openai_raises_when_pdf_conversion_fails(self, mock_create):
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output.return_value = MagicMock()
+        mock_create.return_value = mock_llm
+
+        ext = DocumentExtractor(model="gpt-4o-mini", api_key="fake")
+
+        with patch.object(ext, "_pdf_to_image", return_value=None):
+            with patch.object(ext, "_check_orientation", return_value=0):
+                with pytest.raises(ValueError, match="No se pudo convertir el PDF"):
+                    ext._extract_with_pdf(Path("/fake/file.pdf"))
+
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_anthropic_uses_native_pdf(self, mock_create):
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output.return_value.invoke.return_value = {"field": "value"}
+        mock_create.return_value = mock_llm
+
+        ext = DocumentExtractor(model="claude-haiku-4-5-20251001", api_key="fake")
+
+        fake_img = MagicMock()
+        fake_img.width = 100
+        fake_img.height = 100
+        fake_img.save = MagicMock(side_effect=lambda buf, **kw: buf.write(b"\xff\xd8fake"))
+
+        with (
+            patch.object(ext, "_pdf_to_image", return_value=fake_img),
+            patch.object(ext, "_check_orientation", return_value=0),
+            patch("pathlib.Path.read_bytes", return_value=b"%PDF-fake"),
+        ):
+            ext._extract_with_pdf(Path("/fake/file.pdf"))
+
+        # Should call structured_llm.invoke with native PDF content, not vision
+        call_args = ext.structured_llm.invoke.call_args[0][0][0]
+        content = call_args.content
+        assert content[0]["type"] == "file"
+        assert content[0]["mime_type"] == "application/pdf"
+
+
+class TestExtractFileWithImageUrl:
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_image_url_skips_base64(self, mock_create):
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output.return_value.invoke.return_value = {
+            "is_valid_document": True,
+            "owner": "Test",
+            "account_number": "012345678901234567",
+            "bank_name": "BBVA",
+        }
+        mock_create.return_value = mock_llm
+
+        ext = DocumentExtractor(model="gpt-4o-mini", api_key="fake")
+
+        with patch.object(ext, "_load_image_file") as mock_load:
+            result = ext.extract_file(
+                Path("/fake/file.jpg"), image_url="https://s3.example.com/file.jpg"
+            )
+
+        mock_load.assert_not_called()
+        assert result["owner"] == "Test"
+
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_pdf_ignores_image_url(self, mock_create):
+        """PDFs always go through _extract_with_pdf, image_url is not used."""
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output.return_value.invoke.return_value = {"field": "value"}
+        mock_create.return_value = mock_llm
+
+        ext = DocumentExtractor(model="claude-haiku-4-5-20251001", api_key="fake")
+
+        with patch.object(ext, "_extract_with_pdf", return_value={"field": "value"}) as mock_pdf:
+            ext.extract_file(
+                Path("/fake/file.pdf"), image_url="https://s3.example.com/file.pdf"
+            )
+
+        mock_pdf.assert_called_once()
+
+
+class TestStorageDownloadUrl:
+    def test_local_storage_returns_none(self):
+        from src.infrastructure.storage import LocalStorage
+
+        storage = LocalStorage()
+        assert storage.generate_download_url("some-key") is None

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -404,6 +404,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "jinja2" },
     { name = "langchain-anthropic" },
+    { name = "langchain-openai" },
     { name = "pdf2image" },
     { name = "pdfplumber" },
     { name = "pillow" },
@@ -438,6 +439,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "langchain-anthropic", specifier = ">=0.3.0" },
+    { name = "langchain-openai", specifier = ">=0.3.0" },
     { name = "pdf2image", specifier = ">=1.16.0" },
     { name = "pdfplumber", specifier = ">=0.10.0" },
     { name = "pillow", specifier = ">=10.0.0" },
@@ -826,7 +828,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.17"
+version = "1.2.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -838,9 +840,23 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/93/36226f593df52b871fc24d494c274f3a6b2ac76763a2806e7d35611634a1/langchain_core-1.2.17.tar.gz", hash = "sha256:54aa267f3311e347fb2e50951fe08e53761cebfb999ab80e6748d70525bbe872", size = 836130, upload-time = "2026-03-02T22:47:55.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/a3/c4cd6827a1df46c821e7214b7f7b7a28b189e6c9b84ef15c6d629c5e3179/langchain_core-1.2.22.tar.gz", hash = "sha256:8d8f726d03d3652d403da915126626bb6250747e8ba406537d849e68b9f5d058", size = 842487, upload-time = "2026-03-24T18:48:44.9Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/90/073f33ab383a62908eca7ea699586dfea280e77182176e33199c80ddf22a/langchain_core-1.2.17-py3-none-any.whl", hash = "sha256:bf6bd6ce503874e9c2da1669a69383e967c3de1ea808921d19a9a6bff1a9fbbe", size = 502727, upload-time = "2026-03-02T22:47:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/2ffacf0f1a3788f250e75d0b52a24896c413be11be3a6d42bcdf46fbea48/langchain_core-1.2.22-py3-none-any.whl", hash = "sha256:7e30d586b75918e828833b9ec1efc25465723566845dd652c277baf751e9c04b", size = 506829, upload-time = "2026-03-24T18:48:43.286Z" },
+]
+
+[[package]]
+name = "langchain-openai"
+version = "1.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/fd/7dee16e882c4c1577d48db174d85aa3a0ee09ba61eb6a5d41650285ca80c/langchain_openai-1.1.12.tar.gz", hash = "sha256:ccf5ef02c896f6807b4d0e51aaf678a72ce81ae41201cae8d65e11eeff9ecb79", size = 1114119, upload-time = "2026-03-23T18:59:19.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/a6/68fb22e3604015e6f546fa1d3677d24378b482855ae74710cbf4aec44132/langchain_openai-1.1.12-py3-none-any.whl", hash = "sha256:da71ca3f2d18c16f7a2443cc306aa195ad2a07054335ac9b0626dcae02b6a0c5", size = 88487, upload-time = "2026-03-23T18:59:17.978Z" },
 ]
 
 [[package]]
@@ -1051,6 +1067,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/55/6e1a61ded7af8df04016d81b5b02daa59f2ea9252ee0397cb9f631efe9e5/numpy-2.4.2-cp314-cp314t-win32.whl", hash = "sha256:8c50dd1fc8826f5b26a5ee4d77ca55d88a895f4e4819c7ecc2a9f5905047a443", size = 6153937, upload-time = "2026-01-31T23:12:47.229Z" },
     { url = "https://files.pythonhosted.org/packages/45/aa/fa6118d1ed6d776b0983f3ceac9b1a5558e80df9365b1c3aa6d42bf9eee4/numpy-2.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fcf92bee92742edd401ba41135185866f7026c502617f422eb432cfeca4fe236", size = 12631844, upload-time = "2026-01-31T23:12:48.997Z" },
     { url = "https://files.pythonhosted.org/packages/32/0a/2ec5deea6dcd158f254a7b372fb09cfba5719419c8d66343bab35237b3fb/numpy-2.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:1f92f53998a17265194018d1cc321b2e96e900ca52d54c7c77837b71b9465181", size = 10565379, upload-time = "2026-01-31T23:12:51.345Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
 ]
 
 [[package]]
@@ -1582,6 +1617,94 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.2.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/71/41455aa99a5a5ac1eaf311f5d8efd9ce6433c03ac1e0962de163350d0d97/regex-2026.2.28.tar.gz", hash = "sha256:a729e47d418ea11d03469f321aaf67cdee8954cde3ff2cf8403ab87951ad10f2", size = 415184, upload-time = "2026-02-28T02:19:42.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/42/9061b03cf0fc4b5fa2c3984cbbaed54324377e440a5c5a29d29a72518d62/regex-2026.2.28-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fcf26c3c6d0da98fada8ae4ef0aa1c3405a431c0a77eb17306d38a89b02adcd7", size = 489574, upload-time = "2026-02-28T02:16:50.455Z" },
+    { url = "https://files.pythonhosted.org/packages/77/83/0c8a5623a233015595e3da499c5a1c13720ac63c107897a6037bb97af248/regex-2026.2.28-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02473c954af35dd2defeb07e44182f5705b30ea3f351a7cbffa9177beb14da5d", size = 291426, upload-time = "2026-02-28T02:16:52.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/06/3ef1ac6910dc3295ebd71b1f9bfa737e82cfead211a18b319d45f85ddd09/regex-2026.2.28-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9b65d33a17101569f86d9c5966a8b1d7fbf8afdda5a8aa219301b0a80f58cf7d", size = 289200, upload-time = "2026-02-28T02:16:54.08Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c9/8cc8d850b35ab5650ff6756a1cb85286e2000b66c97520b29c1587455344/regex-2026.2.28-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71dcecaa113eebcc96622c17692672c2d104b1d71ddf7adeda90da7ddeb26fc", size = 796765, upload-time = "2026-02-28T02:16:55.905Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5d/57702597627fc23278ebf36fbb497ac91c0ce7fec89ac6c81e420ca3e38c/regex-2026.2.28-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:481df4623fa4969c8b11f3433ed7d5e3dc9cec0f008356c3212b3933fb77e3d8", size = 863093, upload-time = "2026-02-28T02:16:58.094Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/f3ecad537ca2811b4d26b54ca848cf70e04fcfc138667c146a9f3157779c/regex-2026.2.28-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:64e7c6ad614573e0640f271e811a408d79a9e1fe62a46adb602f598df42a818d", size = 909455, upload-time = "2026-02-28T02:17:00.918Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/40/bb226f203caa22c1043c1ca79b36340156eca0f6a6742b46c3bb222a3a57/regex-2026.2.28-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6b08a06976ff4fb0d83077022fde3eca06c55432bb997d8c0495b9a4e9872f4", size = 802037, upload-time = "2026-02-28T02:17:02.842Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7c/c6d91d8911ac6803b45ca968e8e500c46934e58c0903cbc6d760ee817a0a/regex-2026.2.28-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:864cdd1a2ef5716b0ab468af40139e62ede1b3a53386b375ec0786bb6783fc05", size = 775113, upload-time = "2026-02-28T02:17:04.506Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/4a9368d168d47abd4158580b8c848709667b1cd293ff0c0c277279543bd0/regex-2026.2.28-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:511f7419f7afab475fd4d639d4aedfc54205bcb0800066753ef68a59f0f330b5", size = 784194, upload-time = "2026-02-28T02:17:06.888Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bf/2c72ab5d8b7be462cb1651b5cc333da1d0068740342f350fcca3bca31947/regex-2026.2.28-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b42f7466e32bf15a961cf09f35fa6323cc72e64d3d2c990b10de1274a5da0a59", size = 856846, upload-time = "2026-02-28T02:17:09.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f4/6b65c979bb6d09f51bb2d2a7bc85de73c01ec73335d7ddd202dcb8cd1c8f/regex-2026.2.28-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8710d61737b0c0ce6836b1da7109f20d495e49b3809f30e27e9560be67a257bf", size = 763516, upload-time = "2026-02-28T02:17:11.004Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/29ea5e27400ee86d2cc2b4e80aa059df04eaf78b4f0c18576ae077aeff68/regex-2026.2.28-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4390c365fd2d45278f45afd4673cb90f7285f5701607e3ad4274df08e36140ae", size = 849278, upload-time = "2026-02-28T02:17:12.693Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/91/3233d03b5f865111cd517e1c95ee8b43e8b428d61fa73764a80c9bb6f537/regex-2026.2.28-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cb3b1db8ff6c7b8bf838ab05583ea15230cb2f678e569ab0e3a24d1e8320940b", size = 790068, upload-time = "2026-02-28T02:17:14.9Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/abc706c1fb03b4580a09645b206a3fc032f5a9f457bc1a8038ac555658ab/regex-2026.2.28-cp312-cp312-win32.whl", hash = "sha256:f8ed9a5d4612df9d4de15878f0bc6aa7a268afbe5af21a3fdd97fa19516e978c", size = 266416, upload-time = "2026-02-28T02:17:17.15Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/2a6f7dff190e5fa9df9fb4acf2fdf17a1aa0f7f54596cba8de608db56b3a/regex-2026.2.28-cp312-cp312-win_amd64.whl", hash = "sha256:01d65fd24206c8e1e97e2e31b286c59009636c022eb5d003f52760b0f42155d4", size = 277297, upload-time = "2026-02-28T02:17:18.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/58a2484851fadf284458fdbd728f580d55c1abac059ae9f048c63b92f427/regex-2026.2.28-cp312-cp312-win_arm64.whl", hash = "sha256:c0b5ccbb8ffb433939d248707d4a8b31993cb76ab1a0187ca886bf50e96df952", size = 270408, upload-time = "2026-02-28T02:17:20.328Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f6/dc9ef48c61b79c8201585bf37fa70cd781977da86e466cd94e8e95d2443b/regex-2026.2.28-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6d63a07e5ec8ce7184452cb00c41c37b49e67dc4f73b2955b5b8e782ea970784", size = 489311, upload-time = "2026-02-28T02:17:22.591Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c8/c20390f2232d3f7956f420f4ef1852608ad57aa26c3dd78516cb9f3dc913/regex-2026.2.28-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e59bc8f30414d283ae8ee1617b13d8112e7135cb92830f0ec3688cb29152585a", size = 291285, upload-time = "2026-02-28T02:17:24.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a6/ba1068a631ebd71a230e7d8013fcd284b7c89c35f46f34a7da02082141b1/regex-2026.2.28-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:de0cf053139f96219ccfabb4a8dd2d217c8c82cb206c91d9f109f3f552d6b43d", size = 289051, upload-time = "2026-02-28T02:17:26.722Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1b/7cc3b7af4c244c204b7a80924bd3d85aecd9ba5bc82b485c5806ee8cda9e/regex-2026.2.28-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb4db2f17e6484904f986c5a657cec85574c76b5c5e61c7aae9ffa1bc6224f95", size = 796842, upload-time = "2026-02-28T02:17:29.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/87/26bd03efc60e0d772ac1e7b60a2e6325af98d974e2358f659c507d3c76db/regex-2026.2.28-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:52b017b35ac2214d0db5f4f90e303634dc44e4aba4bd6235a27f97ecbe5b0472", size = 863083, upload-time = "2026-02-28T02:17:31.363Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/54/aeaf4afb1aa0a65e40de52a61dc2ac5b00a83c6cb081c8a1d0dda74f3010/regex-2026.2.28-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:69fc560ccbf08a09dc9b52ab69cacfae51e0ed80dc5693078bdc97db2f91ae96", size = 909412, upload-time = "2026-02-28T02:17:33.248Z" },
+    { url = "https://files.pythonhosted.org/packages/12/2f/049901def913954e640d199bbc6a7ca2902b6aeda0e5da9d17f114100ec2/regex-2026.2.28-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e61eea47230eba62a31f3e8a0e3164d0f37ef9f40529fb2c79361bc6b53d2a92", size = 802101, upload-time = "2026-02-28T02:17:35.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/512fb9ff7f5b15ea204bb1967ebb649059446decacccb201381f9fa6aad4/regex-2026.2.28-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4f5c0b182ad4269e7381b7c27fdb0408399881f7a92a4624fd5487f2971dfc11", size = 775260, upload-time = "2026-02-28T02:17:37.692Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/9a92935878aba19bd72706b9db5646a6f993d99b3f6ed42c02ec8beb1d61/regex-2026.2.28-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:96f6269a2882fbb0ee76967116b83679dc628e68eaea44e90884b8d53d833881", size = 784311, upload-time = "2026-02-28T02:17:39.855Z" },
+    { url = "https://files.pythonhosted.org/packages/09/d3/fc51a8a738a49a6b6499626580554c9466d3ea561f2b72cfdc72e4149773/regex-2026.2.28-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b5acd4b6a95f37c3c3828e5d053a7d4edaedb85de551db0153754924cb7c83e3", size = 856876, upload-time = "2026-02-28T02:17:42.317Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b7/2e641f3d084b120ca4c52e8c762a78da0b32bf03ef546330db3e2635dc5f/regex-2026.2.28-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2234059cfe33d9813a3677ef7667999caea9eeaa83fef98eb6ce15c6cf9e0215", size = 763632, upload-time = "2026-02-28T02:17:45.073Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6d/0009021d97e79ee99f3d8641f0a8d001eed23479ade4c3125a5480bf3e2d/regex-2026.2.28-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c15af43c72a7fb0c97cbc66fa36a43546eddc5c06a662b64a0cbf30d6ac40944", size = 849320, upload-time = "2026-02-28T02:17:47.192Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7a/51cfbad5758f8edae430cb21961a9c8d04bce1dae4d2d18d4186eec7cfa1/regex-2026.2.28-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9185cc63359862a6e80fe97f696e04b0ad9a11c4ac0a4a927f979f611bfe3768", size = 790152, upload-time = "2026-02-28T02:17:49.067Z" },
+    { url = "https://files.pythonhosted.org/packages/90/3d/a83e2b6b3daa142acb8c41d51de3876186307d5cb7490087031747662500/regex-2026.2.28-cp313-cp313-win32.whl", hash = "sha256:fb66e5245db9652abd7196ace599b04d9c0e4aa7c8f0e2803938377835780081", size = 266398, upload-time = "2026-02-28T02:17:50.744Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/16e9ebb1fe5425e11b9596c8d57bf8877dcb32391da0bfd33742e3290637/regex-2026.2.28-cp313-cp313-win_amd64.whl", hash = "sha256:71a911098be38c859ceb3f9a9ce43f4ed9f4c6720ad8684a066ea246b76ad9ff", size = 277282, upload-time = "2026-02-28T02:17:53.074Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b4/92851335332810c5a89723bf7a7e35c7209f90b7d4160024501717b28cc9/regex-2026.2.28-cp313-cp313-win_arm64.whl", hash = "sha256:39bb5727650b9a0275c6a6690f9bb3fe693a7e6cc5c3155b1240aedf8926423e", size = 270382, upload-time = "2026-02-28T02:17:54.888Z" },
+    { url = "https://files.pythonhosted.org/packages/24/07/6c7e4cec1e585959e96cbc24299d97e4437a81173217af54f1804994e911/regex-2026.2.28-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:97054c55db06ab020342cc0d35d6f62a465fa7662871190175f1ad6c655c028f", size = 492541, upload-time = "2026-02-28T02:17:56.813Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/13/55eb22ada7f43d4f4bb3815b6132183ebc331c81bd496e2d1f3b8d862e0d/regex-2026.2.28-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0d25a10811de831c2baa6aef3c0be91622f44dd8d31dd12e69f6398efb15e48b", size = 292984, upload-time = "2026-02-28T02:17:58.538Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/c301f8cb29ce9644a5ef85104c59244e6e7e90994a0f458da4d39baa8e17/regex-2026.2.28-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d6cfe798d8da41bb1862ed6e0cba14003d387c3c0c4a5d45591076ae9f0ce2f8", size = 291509, upload-time = "2026-02-28T02:18:00.208Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/43/aabe384ec1994b91796e903582427bc2ffaed9c4103819ed3c16d8e749f3/regex-2026.2.28-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd0ce43e71d825b7c0661f9c54d4d74bd97c56c3fd102a8985bcfea48236bacb", size = 809429, upload-time = "2026-02-28T02:18:02.328Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b8/8d2d987a816720c4f3109cee7c06a4b24ad0e02d4fc74919ab619e543737/regex-2026.2.28-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:00945d007fd74a9084d2ab79b695b595c6b7ba3698972fadd43e23230c6979c1", size = 869422, upload-time = "2026-02-28T02:18:04.23Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ad/2c004509e763c0c3719f97c03eca26473bffb3868d54c5f280b8cd4f9e3d/regex-2026.2.28-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bec23c11cbbf09a4df32fe50d57cbdd777bc442269b6e39a1775654f1c95dee2", size = 915175, upload-time = "2026-02-28T02:18:06.791Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c2/fd429066da487ef555a9da73bf214894aec77fc8c66a261ee355a69871a8/regex-2026.2.28-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5cdcc17d935c8f9d3f4db5c2ebe2640c332e3822ad5d23c2f8e0228e6947943a", size = 812044, upload-time = "2026-02-28T02:18:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ca/feedb7055c62a3f7f659971bf45f0e0a87544b6b0cf462884761453f97c5/regex-2026.2.28-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a448af01e3d8031c89c5d902040b124a5e921a25c4e5e07a861ca591ce429341", size = 782056, upload-time = "2026-02-28T02:18:10.777Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/1aa959ed0d25c1dd7dd5047ea8ba482ceaef38ce363c401fd32a6b923e60/regex-2026.2.28-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:10d28e19bd4888e4abf43bd3925f3c134c52fdf7259219003588a42e24c2aa25", size = 798743, upload-time = "2026-02-28T02:18:13.025Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/1f/dadb9cf359004784051c897dcf4d5d79895f73a1bbb7b827abaa4814ae80/regex-2026.2.28-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:99985a2c277dcb9ccb63f937451af5d65177af1efdeb8173ac55b61095a0a05c", size = 864633, upload-time = "2026-02-28T02:18:16.84Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f1/b9a25eb24e1cf79890f09e6ec971ee5b511519f1851de3453bc04f6c902b/regex-2026.2.28-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:e1e7b24cb3ae9953a560c563045d1ba56ee4749fbd05cf21ba571069bd7be81b", size = 770862, upload-time = "2026-02-28T02:18:18.892Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/c5cb10b7aa6f182f9247a30cc9527e326601f46f4df864ac6db588d11fcd/regex-2026.2.28-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d8511a01d0e4ee1992eb3ba19e09bc1866fe03f05129c3aec3fdc4cbc77aad3f", size = 854788, upload-time = "2026-02-28T02:18:21.475Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/50/414ba0731c4bd40b011fa4703b2cc86879ec060c64f2a906e65a56452589/regex-2026.2.28-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:aaffaecffcd2479ce87aa1e74076c221700b7c804e48e98e62500ee748f0f550", size = 800184, upload-time = "2026-02-28T02:18:23.492Z" },
+    { url = "https://files.pythonhosted.org/packages/69/50/0c7290987f97e7e6830b0d853f69dc4dc5852c934aae63e7fdcd76b4c383/regex-2026.2.28-cp313-cp313t-win32.whl", hash = "sha256:ef77bdde9c9eba3f7fa5b58084b29bbcc74bcf55fdbeaa67c102a35b5bd7e7cc", size = 269137, upload-time = "2026-02-28T02:18:25.375Z" },
+    { url = "https://files.pythonhosted.org/packages/68/80/ef26ff90e74ceb4051ad6efcbbb8a4be965184a57e879ebcbdef327d18fa/regex-2026.2.28-cp313-cp313t-win_amd64.whl", hash = "sha256:98adf340100cbe6fbaf8e6dc75e28f2c191b1be50ffefe292fb0e6f6eefdb0d8", size = 280682, upload-time = "2026-02-28T02:18:27.205Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/fbad9c52e83ffe8f97e3ed1aa0516e6dff6bb633a41da9e64645bc7efdc5/regex-2026.2.28-cp313-cp313t-win_arm64.whl", hash = "sha256:2fb950ac1d88e6b6a9414381f403797b236f9fa17e1eee07683af72b1634207b", size = 271735, upload-time = "2026-02-28T02:18:29.015Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/03/691015f7a7cb1ed6dacb2ea5de5682e4858e05a4c5506b2839cd533bbcd6/regex-2026.2.28-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:78454178c7df31372ea737996fb7f36b3c2c92cccc641d251e072478afb4babc", size = 489497, upload-time = "2026-02-28T02:18:30.889Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ba/8db8fd19afcbfa0e1036eaa70c05f20ca8405817d4ad7a38a6b4c2f031ac/regex-2026.2.28-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:5d10303dd18cedfd4d095543998404df656088240bcfd3cd20a8f95b861f74bd", size = 291295, upload-time = "2026-02-28T02:18:33.426Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/79/9aa0caf089e8defef9b857b52fc53801f62ff868e19e5c83d4a96612eba1/regex-2026.2.28-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:19a9c9e0a8f24f39d575a6a854d516b48ffe4cbdcb9de55cb0570a032556ecff", size = 289275, upload-time = "2026-02-28T02:18:35.247Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/26/ee53117066a30ef9c883bf1127eece08308ccf8ccd45c45a966e7a665385/regex-2026.2.28-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09500be324f49b470d907b3ef8af9afe857f5cca486f853853f7945ddbf75911", size = 797176, upload-time = "2026-02-28T02:18:37.15Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1b/67fb0495a97259925f343ae78b5d24d4a6624356ae138b57f18bd43006e4/regex-2026.2.28-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fb1c4ff62277d87a7335f2c1ea4e0387b8f2b3ad88a64efd9943906aafad4f33", size = 863813, upload-time = "2026-02-28T02:18:39.478Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/93ac9bbafc53618091c685c7ed40239a90bf9f2a82c983f0baa97cb7ae07/regex-2026.2.28-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b8b3f1be1738feadc69f62daa250c933e85c6f34fa378f54a7ff43807c1b9117", size = 908678, upload-time = "2026-02-28T02:18:41.619Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7a/a8f5e0561702b25239846a16349feece59712ae20598ebb205580332a471/regex-2026.2.28-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc8ed8c3f41c27acb83f7b6a9eb727a73fc6663441890c5cb3426a5f6a91ce7d", size = 801528, upload-time = "2026-02-28T02:18:43.624Z" },
+    { url = "https://files.pythonhosted.org/packages/96/5d/ed6d4cbde80309854b1b9f42d9062fee38ade15f7eb4909f6ef2440403b5/regex-2026.2.28-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa539be029844c0ce1114762d2952ab6cfdd7c7c9bd72e0db26b94c3c36dcc5a", size = 775373, upload-time = "2026-02-28T02:18:46.102Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/e9/6e53c34e8068b9deec3e87210086ecb5b9efebdefca6b0d3fa43d66dcecb/regex-2026.2.28-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7900157786428a79615a8264dac1f12c9b02957c473c8110c6b1f972dcecaddf", size = 784859, upload-time = "2026-02-28T02:18:48.269Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3c/736e1c7ca7f0dcd2ae33819888fdc69058a349b7e5e84bc3e2f296bbf794/regex-2026.2.28-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0b1d2b07614d95fa2bf8a63fd1e98bd8fa2b4848dc91b1efbc8ba219fdd73952", size = 857813, upload-time = "2026-02-28T02:18:50.576Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/7c/48c4659ad9da61f58e79dbe8c05223e0006696b603c16eb6b5cbfbb52c27/regex-2026.2.28-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b389c61aa28a79c2e0527ac36da579869c2e235a5b208a12c5b5318cda2501d8", size = 763705, upload-time = "2026-02-28T02:18:52.59Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a1/bc1c261789283128165f71b71b4b221dd1b79c77023752a6074c102f18d8/regex-2026.2.28-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f467cb602f03fbd1ab1908f68b53c649ce393fde056628dc8c7e634dab6bfc07", size = 848734, upload-time = "2026-02-28T02:18:54.595Z" },
+    { url = "https://files.pythonhosted.org/packages/10/d8/979407faf1397036e25a5ae778157366a911c0f382c62501009f4957cf86/regex-2026.2.28-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c8cb2deba42f5ec1ede46374e990f8adc5e6456a57ac1a261b19be6f28e4e6", size = 789871, upload-time = "2026-02-28T02:18:57.34Z" },
+    { url = "https://files.pythonhosted.org/packages/03/23/da716821277115fcb1f4e3de1e5dc5023a1e6533598c486abf5448612579/regex-2026.2.28-cp314-cp314-win32.whl", hash = "sha256:9036b400b20e4858d56d117108d7813ed07bb7803e3eed766675862131135ca6", size = 271825, upload-time = "2026-02-28T02:18:59.202Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ff/90696f535d978d5f16a52a419be2770a8d8a0e7e0cfecdbfc31313df7fab/regex-2026.2.28-cp314-cp314-win_amd64.whl", hash = "sha256:1d367257cd86c1cbb97ea94e77b373a0bbc2224976e247f173d19e8f18b4afa7", size = 280548, upload-time = "2026-02-28T02:19:01.049Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f9/5e1b5652fc0af3fcdf7677e7df3ad2a0d47d669b34ac29a63bb177bb731b/regex-2026.2.28-cp314-cp314-win_arm64.whl", hash = "sha256:5e68192bb3a1d6fb2836da24aa494e413ea65853a21505e142e5b1064a595f3d", size = 273444, upload-time = "2026-02-28T02:19:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/eb/8389f9e940ac89bcf58d185e230a677b4fd07c5f9b917603ad5c0f8fa8fe/regex-2026.2.28-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:a5dac14d0872eeb35260a8e30bac07ddf22adc1e3a0635b52b02e180d17c9c7e", size = 492546, upload-time = "2026-02-28T02:19:05.378Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/c7/09441d27ce2a6fa6a61ea3150ea4639c1dcda9b31b2ea07b80d6937b24dd/regex-2026.2.28-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ec0c608b7a7465ffadb344ed7c987ff2f11ee03f6a130b569aa74d8a70e8333c", size = 292986, upload-time = "2026-02-28T02:19:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/69/4144b60ed7760a6bd235e4087041f487aa4aa62b45618ce018b0c14833ea/regex-2026.2.28-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7815afb0ca45456613fdaf60ea9c993715511c8d53a83bc468305cbc0ee23c7", size = 291518, upload-time = "2026-02-28T02:19:09.698Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/be/77e5426cf5948c82f98c53582009ca9e94938c71f73a8918474f2e2990bb/regex-2026.2.28-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b059e71ec363968671693a78c5053bd9cb2fe410f9b8e4657e88377ebd603a2e", size = 809464, upload-time = "2026-02-28T02:19:12.494Z" },
+    { url = "https://files.pythonhosted.org/packages/45/99/2c8c5ac90dc7d05c6e7d8e72c6a3599dc08cd577ac476898e91ca787d7f1/regex-2026.2.28-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8cf76f1a29f0e99dcfd7aef1551a9827588aae5a737fe31442021165f1920dc", size = 869553, upload-time = "2026-02-28T02:19:15.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/34/daa66a342f0271e7737003abf6c3097aa0498d58c668dbd88362ef94eb5d/regex-2026.2.28-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:180e08a435a0319e6a4821c3468da18dc7001987e1c17ae1335488dfe7518dd8", size = 915289, upload-time = "2026-02-28T02:19:17.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/c7/e22c2aaf0a12e7e22ab19b004bb78d32ca1ecc7ef245949935463c5567de/regex-2026.2.28-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e496956106fd59ba6322a8ea17141a27c5040e5ee8f9433ae92d4e5204462a0", size = 812156, upload-time = "2026-02-28T02:19:20.011Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/bb/2dc18c1efd9051cf389cd0d7a3a4d90f6804b9fff3a51b5dc3c85b935f71/regex-2026.2.28-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bba2b18d70eeb7b79950f12f633beeecd923f7c9ad6f6bae28e59b4cb3ab046b", size = 782215, upload-time = "2026-02-28T02:19:22.047Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1e/9e4ec9b9013931faa32226ec4aa3c71fe664a6d8a2b91ac56442128b332f/regex-2026.2.28-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6db7bfae0f8a2793ff1f7021468ea55e2699d0790eb58ee6ab36ae43aa00bc5b", size = 798925, upload-time = "2026-02-28T02:19:24.173Z" },
+    { url = "https://files.pythonhosted.org/packages/71/57/a505927e449a9ccb41e2cc8d735e2abe3444b0213d1cf9cb364a8c1f2524/regex-2026.2.28-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:d0b02e8b7e5874b48ae0f077ecca61c1a6a9f9895e9c6dfb191b55b242862033", size = 864701, upload-time = "2026-02-28T02:19:26.376Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ad/c62cb60cdd93e13eac5b3d9d6bd5d284225ed0e3329426f94d2552dd7cca/regex-2026.2.28-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:25b6eb660c5cf4b8c3407a1ed462abba26a926cc9965e164268a3267bcc06a43", size = 770899, upload-time = "2026-02-28T02:19:29.38Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/5a/874f861f5c3d5ab99633e8030dee1bc113db8e0be299d1f4b07f5b5ec349/regex-2026.2.28-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:5a932ea8ad5d0430351ff9c76c8db34db0d9f53c1d78f06022a21f4e290c5c18", size = 854727, upload-time = "2026-02-28T02:19:31.494Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ca/d2c03b0efde47e13db895b975b2be6a73ed90b8ba963677927283d43bf74/regex-2026.2.28-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1c2c95e1a2b0f89d01e821ff4de1be4b5d73d1f4b0bf679fa27c1ad8d2327f1a", size = 800366, upload-time = "2026-02-28T02:19:34.248Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bd/ee13b20b763b8989f7c75d592bfd5de37dc1181814a2a2747fedcf97e3ba/regex-2026.2.28-cp314-cp314t-win32.whl", hash = "sha256:bbb882061f742eb5d46f2f1bd5304055be0a66b783576de3d7eef1bed4778a6e", size = 274936, upload-time = "2026-02-28T02:19:36.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e7/d8020e39414c93af7f0d8688eabcecece44abfd5ce314b21dfda0eebd3d8/regex-2026.2.28-cp314-cp314t-win_amd64.whl", hash = "sha256:6591f281cb44dc13de9585b552cec6fc6cf47fb2fe7a48892295ee9bc4a612f9", size = 284779, upload-time = "2026-02-28T02:19:38.625Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c0/ad225f4a405827486f1955283407cf758b6d2fb966712644c5f5aef33d1b/regex-2026.2.28-cp314-cp314t-win_arm64.whl", hash = "sha256:dee50f1be42222f89767b64b283283ef963189da0dda4a515aa54a5563c62dec", size = 275010, upload-time = "2026-02-28T02:19:40.65Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1743,6 +1866,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
+    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
+    { url = "https://files.pythonhosted.org/packages/72/05/3abc1db5d2c9aadc4d2c76fa5640134e475e58d9fbb82b5c535dc0de9b01/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646", size = 1050188, upload-time = "2025-10-06T20:22:19.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
+    { url = "https://files.pythonhosted.org/packages/14/27/bf795595a2b897e271771cd31cb847d479073497344c637966bdf2853da1/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff", size = 1129271, upload-time = "2025-10-06T20:22:22.06Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/9341a6d7a8f1b448573bbf3425fa57669ac58258a667eb48a25dfe916d70/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830", size = 1151216, upload-time = "2025-10-06T20:22:23.085Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0d/881866647b8d1be4d67cb24e50d0c26f9f807f994aa1510cb9ba2fe5f612/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b", size = 1194860, upload-time = "2025-10-06T20:22:24.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/b651ec3059474dab649b8d5b69f5c65cd8fcd8918568c1935bd4136c9392/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b", size = 1254567, upload-time = "2025-10-06T20:22:25.671Z" },
+    { url = "https://files.pythonhosted.org/packages/80/57/ce64fd16ac390fafde001268c364d559447ba09b509181b2808622420eec/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3", size = 921067, upload-time = "2025-10-06T20:22:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a4/72eed53e8976a099539cdd5eb36f241987212c29629d0a52c305173e0a68/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365", size = 1050473, upload-time = "2025-10-06T20:22:27.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/77/4f268c41a3957c418b084dd576ea2fad2e95da0d8e1ab705372892c2ca22/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63", size = 1129022, upload-time = "2025-10-06T20:22:29.981Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2b/fc46c90fe5028bd094cd6ee25a7db321cb91d45dc87531e2bdbb26b4867a/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0", size = 1150736, upload-time = "2025-10-06T20:22:30.996Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -199,9 +199,9 @@ export default function Home() {
           <Select
             value={selectedExtractorId?.toString() ?? ""}
             onValueChange={(v) => {
+              if (file && !window.confirm(t("extraction.confirmChangeExtractor"))) return;
+              resetStore();
               setSelectedExtractorId(v);
-              setExtracted(null);
-              setFormData({});
               setError(null);
               setSuccess(false);
             }}

--- a/frontend/components/dynamic-fields-form.tsx
+++ b/frontend/components/dynamic-fields-form.tsx
@@ -2,11 +2,22 @@
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 import { toStr } from "@/lib/utils";
 import { useT } from "@/lib/i18n";
+import { Plus, Trash2 } from "lucide-react";
+
+interface SchemaProperty {
+  type?: string;
+  description?: string;
+  items?: {
+    type?: string;
+    properties?: Record<string, { type?: string; description?: string }>;
+  };
+}
 
 interface JsonSchema {
-  properties?: Record<string, { type?: string; description?: string }>;
+  properties?: Record<string, SchemaProperty>;
   required?: string[];
 }
 
@@ -15,6 +26,118 @@ interface DynamicFieldsFormProps {
   values: Record<string, string>;
   extracted?: Record<string, unknown>;
   onChange: (field: string, value: string) => void;
+}
+
+function parseArray(value: string): Record<string, unknown>[] {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return [];
+  }
+}
+
+function EditableArrayTable({
+  value,
+  schema,
+  onChange,
+}: {
+  value: string;
+  schema?: SchemaProperty["items"];
+  onChange: (json: string) => void;
+}) {
+  const t = useT();
+  const items = parseArray(value);
+  const columns = Object.keys(schema?.properties ?? items[0] ?? {});
+
+  if (columns.length === 0 && items.length === 0) {
+    return <p className="text-sm text-gray-500 italic">—</p>;
+  }
+
+  const update = (rowIdx: number, col: string, cellValue: string) => {
+    const next = items.map((item, i) =>
+      i === rowIdx ? { ...item, [col]: cellValue } : item
+    );
+    onChange(JSON.stringify(next));
+  };
+
+  const addRow = () => {
+    const empty: Record<string, unknown> = {};
+    for (const col of columns) empty[col] = "";
+    onChange(JSON.stringify([...items, empty]));
+  };
+
+  const removeRow = (rowIdx: number) => {
+    onChange(JSON.stringify(items.filter((_, i) => i !== rowIdx)));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="overflow-x-auto rounded-lg border border-gray-200">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-gray-50 border-b border-gray-200">
+              {columns.map((col) => (
+                <th
+                  key={col}
+                  className="px-2 py-2 text-left font-medium text-gray-600 capitalize whitespace-nowrap text-xs"
+                >
+                  {col.replace(/_/g, " ")}
+                </th>
+              ))}
+              <th className="w-10" />
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item, i) => (
+              <tr key={i} className={i % 2 === 0 ? "bg-white" : "bg-gray-50"}>
+                {columns.map((col) => (
+                  <td key={col} className="px-1 py-1">
+                    <Input
+                      value={toStr(item[col])}
+                      onChange={(e) => update(i, col, e.target.value)}
+                      className="h-8 text-sm"
+                    />
+                  </td>
+                ))}
+                <td className="px-1 py-1 text-center">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-gray-400 hover:text-red-500"
+                    onClick={() => removeRow(i)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+            {items.length === 0 && (
+              <tr>
+                <td
+                  colSpan={columns.length + 1}
+                  className="px-3 py-4 text-center text-sm text-gray-400"
+                >
+                  {t("dynamicFields.noItems")}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-full"
+        onClick={addRow}
+      >
+        <Plus className="h-4 w-4 mr-1" />
+        {t("dynamicFields.addItem")}
+      </Button>
+    </div>
+  );
 }
 
 export function DynamicFieldsForm({
@@ -39,7 +162,13 @@ export function DynamicFieldsForm({
             <Label htmlFor={`field-${key}`} className="capitalize">
               {key.replace(/_/g, " ")}
             </Label>
-            {prop.type === "boolean" ? (
+            {prop.type === "array" ? (
+              <EditableArrayTable
+                value={currentValue}
+                schema={prop.items}
+                onChange={(json) => onChange(key, json)}
+              />
+            ) : prop.type === "boolean" ? (
               <div className="flex items-center gap-2">
                 <input
                   type="checkbox"
@@ -72,7 +201,7 @@ export function DynamicFieldsForm({
                 className={isModified ? "border-yellow-400" : ""}
               />
             )}
-            {isModified && (
+            {isModified && prop.type !== "array" && (
               <p className="text-xs text-yellow-600">
                 {t("dynamicFields.aiExtracted", { value: extractedValue || t("dynamicFields.empty") })}
               </p>

--- a/frontend/components/schema-builder/field-card.tsx
+++ b/frontend/components/schema-builder/field-card.tsx
@@ -5,7 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { ChevronUp, ChevronDown, Trash2, Plus, X } from "lucide-react";
 import { FieldTypeSelect } from "./field-type-select";
-import { SchemaField } from "./types";
+import { SchemaField, ArraySubField } from "./types";
 import { useT } from "@/lib/i18n";
 
 interface FieldCardProps {
@@ -94,6 +94,91 @@ function EnumOptionsEditor({
   );
 }
 
+const SUB_TYPE_OPTIONS = [
+  { value: "string", label: "Texto" },
+  { value: "number", label: "Número" },
+  { value: "boolean", label: "Sí/No" },
+];
+
+function ArrayFieldsEditor({
+  fields,
+  onChange,
+}: {
+  fields: ArraySubField[];
+  onChange: (fields: ArraySubField[]) => void;
+}) {
+  const t = useT();
+
+  const addSubField = () => {
+    onChange([...fields, { name: "", type: "string", description: "" }]);
+  };
+
+  const updateSubField = (idx: number, updates: Partial<ArraySubField>) => {
+    onChange(fields.map((f, i) => (i === idx ? { ...f, ...updates } : f)));
+  };
+
+  const removeSubField = (idx: number) => {
+    onChange(fields.filter((_, i) => i !== idx));
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label className="text-xs text-muted-foreground">
+        {t("fieldCard.arrayColumns")}
+      </Label>
+      <div className="space-y-2 pl-2 border-l-2 border-gray-200">
+        {fields.map((sub, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <Input
+              value={sub.name}
+              onChange={(e) => updateSubField(i, { name: e.target.value })}
+              className="text-sm h-8 flex-1"
+              placeholder={t("fieldCard.namePlaceholder")}
+            />
+            <select
+              value={sub.type}
+              onChange={(e) =>
+                updateSubField(i, { type: e.target.value as ArraySubField["type"] })
+              }
+              className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+            >
+              {SUB_TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {t(`fieldTypes.${opt.value}`)}
+                </option>
+              ))}
+            </select>
+            <Input
+              value={sub.description}
+              onChange={(e) => updateSubField(i, { description: e.target.value })}
+              className="text-sm h-8 flex-1"
+              placeholder={t("fieldCard.aiInstructionPlaceholder")}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-red-500 hover:text-red-600 flex-shrink-0"
+              onClick={() => removeSubField(i)}
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        ))}
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={addSubField}
+      >
+        <Plus className="h-3.5 w-3.5 mr-1" />
+        {t("fieldCard.addColumn")}
+      </Button>
+    </div>
+  );
+}
+
 export function FieldCard({
   field,
   index,
@@ -170,8 +255,10 @@ export function FieldCard({
                   onChange={(type) =>
                     onUpdate(
                       type === "enum"
-                        ? { type, enumValues: field.enumValues || [] }
-                        : { type, enumValues: undefined }
+                        ? { type, enumValues: field.enumValues || [], arrayFields: undefined }
+                        : type === "array"
+                          ? { type, arrayFields: field.arrayFields || [], enumValues: undefined }
+                          : { type, enumValues: undefined, arrayFields: undefined }
                     )
                   }
                 />
@@ -195,6 +282,13 @@ export function FieldCard({
             <EnumOptionsEditor
               values={field.enumValues || []}
               onChange={(enumValues) => onUpdate({ enumValues })}
+            />
+          )}
+
+          {field.type === "array" && (
+            <ArrayFieldsEditor
+              fields={field.arrayFields || []}
+              onChange={(arrayFields) => onUpdate({ arrayFields })}
             />
           )}
         </div>

--- a/frontend/components/schema-builder/field-type-select.tsx
+++ b/frontend/components/schema-builder/field-type-select.tsx
@@ -6,15 +6,16 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { FIELD_TYPE_OPTIONS, SchemaField } from "./types";
-import { Type, Hash, ToggleLeft, List, Calendar } from "lucide-react";
+import { Type, Hash, ToggleLeft, List, Calendar, Table } from "lucide-react";
 import { useT } from "@/lib/i18n";
 
-const TYPE_ICONS = {
+const TYPE_ICONS: Record<string, typeof Type> = {
   string: Type,
   number: Hash,
   boolean: ToggleLeft,
   enum: List,
   date: Calendar,
+  array: Table,
 };
 
 interface FieldTypeSelectProps {

--- a/frontend/components/schema-builder/types.ts
+++ b/frontend/components/schema-builder/types.ts
@@ -1,9 +1,16 @@
+export interface ArraySubField {
+  name: string;
+  type: "string" | "number" | "boolean";
+  description: string;
+}
+
 export interface SchemaField {
   id: string;
   name: string;
-  type: "string" | "number" | "boolean" | "enum" | "date";
+  type: "string" | "number" | "boolean" | "enum" | "date" | "array";
   description: string;
   enumValues?: string[];
+  arrayFields?: ArraySubField[];
 }
 
 export const FIELD_TYPE_OPTIONS = [
@@ -12,6 +19,7 @@ export const FIELD_TYPE_OPTIONS = [
   { value: "boolean" as const, label: "Sí/No" },
   { value: "enum" as const, label: "Opciones" },
   { value: "date" as const, label: "Fecha" },
+  { value: "array" as const, label: "Lista" },
 ];
 
 export const VALIDATION_FIELD: SchemaField = {

--- a/frontend/components/schema-builder/use-schema-fields.ts
+++ b/frontend/components/schema-builder/use-schema-fields.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { SchemaField, VALIDATION_FIELD } from "./types";
+import { SchemaField, ArraySubField, VALIDATION_FIELD } from "./types";
 
 let nextId = 1;
 function genId() {
@@ -26,10 +26,27 @@ export function toJsonSchema(fields: SchemaField[]): JsonSchema {
       properties[f.name] = { type: "string", enum: f.enumValues || [] };
     } else if (f.type === "date") {
       properties[f.name] = { type: "string", format: "date" };
+    } else if (f.type === "array") {
+      const itemProps: Record<string, { type: string; description?: string }> = {};
+      const itemRequired: string[] = [];
+      for (const sub of f.arrayFields || []) {
+        itemProps[sub.name] = { type: sub.type };
+        if (sub.description) itemProps[sub.name].description = sub.description;
+        itemRequired.push(sub.name);
+      }
+      properties[f.name] = {
+        type: "array",
+        description: f.description,
+        items: {
+          type: "object",
+          properties: itemProps,
+          required: itemRequired,
+        },
+      };
     } else {
       properties[f.name] = { type: f.type };
     }
-    if (f.description) {
+    if (f.description && f.type !== "array") {
       properties[f.name].description = f.description;
     }
     required.push(f.name);
@@ -68,6 +85,28 @@ export function fromJsonSchema(
           name: key,
           type: "date",
           description: (prop.description as string) || "",
+        });
+      } else if (fieldType === "array") {
+        const items = prop.items as
+          | { type?: string; properties?: Record<string, { type?: string; description?: string }>; }
+          | undefined;
+        const subFields: ArraySubField[] = [];
+        if (items?.type === "object" && items.properties) {
+          for (const [subKey, subProp] of Object.entries(items.properties)) {
+            const subType = subProp.type as "string" | "number" | "boolean" | undefined;
+            subFields.push({
+              name: subKey,
+              type: subType === "number" || subType === "boolean" ? subType : "string",
+              description: subProp.description || "",
+            });
+          }
+        }
+        fields.push({
+          id: genId(),
+          name: key,
+          type: "array",
+          description: (prop.description as string) || "",
+          arrayFields: subFields,
         });
       } else if (
         fieldType === "string" ||

--- a/frontend/lib/i18n/en.json
+++ b/frontend/lib/i18n/en.json
@@ -59,7 +59,8 @@
     "noFieldsConfigured": "This extractor has no configured fields.",
     "apiNote": "To integrate extraction into your systems, see the",
     "apiDocsLink": "API documentation",
-    "apiNoteSuffix": ". API extractions are tracked in your dashboard."
+    "apiNoteSuffix": ". API extractions are tracked in your dashboard.",
+    "confirmChangeExtractor": "Changing the extractor will reset the current document and results. Continue?"
   },
   "extractors": {
     "loading": "Loading extractors...",
@@ -159,7 +160,9 @@
   },
   "dynamicFields": {
     "aiExtracted": "AI extracted: {value}",
-    "empty": "(empty)"
+    "empty": "(empty)",
+    "noItems": "No items",
+    "addItem": "Add item"
   },
   "wizard": {
     "stepIdentity": "Identity",
@@ -289,7 +292,9 @@
     "willBeUsedAs": "will be used as: {slug}",
     "type": "Type",
     "aiInstruction": "AI instruction",
-    "aiInstructionPlaceholder": "Describe what the AI should extract..."
+    "aiInstructionPlaceholder": "Describe what the AI should extract...",
+    "arrayColumns": "List columns",
+    "addColumn": "Add column"
   },
   "validationField": {
     "title": "Document validation",
@@ -307,7 +312,8 @@
     "number": "Number",
     "boolean": "Yes/No",
     "enum": "Options",
-    "date": "Date"
+    "date": "Date",
+    "array": "List"
   },
   "tokens": {
     "title": "API Tokens",

--- a/frontend/lib/i18n/es.json
+++ b/frontend/lib/i18n/es.json
@@ -59,7 +59,8 @@
     "noFieldsConfigured": "Este extractor no tiene campos configurados.",
     "apiNote": "Para integrar la extracción en tus sistemas, consulta la",
     "apiDocsLink": "documentación de la API",
-    "apiNoteSuffix": ". Las extracciones vía API se registran en tu dashboard."
+    "apiNoteSuffix": ". Las extracciones vía API se registran en tu dashboard.",
+    "confirmChangeExtractor": "Cambiar de extractor reiniciará el documento y los resultados actuales. ¿Deseas continuar?"
   },
   "extractors": {
     "loading": "Cargando extractores...",
@@ -159,7 +160,9 @@
   },
   "dynamicFields": {
     "aiExtracted": "IA extrajo: {value}",
-    "empty": "(vacío)"
+    "empty": "(vacío)",
+    "noItems": "Sin elementos",
+    "addItem": "Agregar elemento"
   },
   "wizard": {
     "stepIdentity": "Identidad",
@@ -289,7 +292,9 @@
     "willBeUsedAs": "se usará como: {slug}",
     "type": "Tipo",
     "aiInstruction": "Instrucción para la IA",
-    "aiInstructionPlaceholder": "Describe qué debe extraer la IA..."
+    "aiInstructionPlaceholder": "Describe qué debe extraer la IA...",
+    "arrayColumns": "Columnas del listado",
+    "addColumn": "Agregar columna"
   },
   "validationField": {
     "title": "Validación del documento",
@@ -307,7 +312,8 @@
     "number": "Número",
     "boolean": "Sí/No",
     "enum": "Opciones",
-    "date": "Fecha"
+    "date": "Fecha",
+    "array": "Lista"
   },
   "tokens": {
     "title": "Tokens API",

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -6,6 +6,8 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function toStr(value: unknown): string {
-  return String(value ?? "");
+  if (value == null) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
 }
 


### PR DESCRIPTION
## Summary
- **Multi-provider LLM support**: Extensible `PROVIDERS` registry supporting Anthropic, OpenAI (`gpt-*`, `o1`, `o3`, `o4`), and Google Gemini (`gemini-*`) with lazy imports and provider-specific image formatting
- **Rename `StatementExtractor` → `DocumentExtractor`**: Extracted bank-statement-specific CLABE retry logic into standalone `retry_bank_statement_clabe()`, gated on `is_default` in `ExtractionService`
- **Array fields support**: Editable table UI for array-type extraction fields (add/remove/edit rows), and "Lista" type in the visual schema builder with configurable sub-field columns
- **UX fixes**: Extractor change resets file+results with confirmation dialog; `toStr` serializes objects as JSON instead of `[object Object]`; presigned download URL passthrough for S3 images

## Test plan
- [x] Backend: 169 tests pass, ruff clean
- [x] Frontend: ESLint clean
- [x] Verified Claude extraction works locally (PDF + image)
- [ ] Verify default extractor (bank statements) works in prod
- [ ] Verify custom extractor with array fields renders correctly
- [ ] Verify changing extractor resets the page with confirm dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)