### PR TITLE
Add privacy policy and privacy endpoints to API docs

### DIFF
--- a/backend/src/infrastructure/api/docs/content.py
+++ b/backend/src/infrastructure/api/docs/content.py
@@ -44,6 +44,7 @@ GROUPS = [
     ("tokens", "Tokens"),
     ("extractors", "Extractores"),
     ("extraction", "Extraccion"),
+    ("privacy", "Privacidad"),
 ]
 
 ENDPOINTS: list[Endpoint] = [
@@ -721,6 +722,153 @@ curl {API_BASE}/extraction/banks \\
   -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" """,
             ),
         ],
+    ),
+    # ── Privacy ──────────────────────────────────────────────────────────
+    Endpoint(
+        method="GET",
+        path="/privacy/consents",
+        slug="list-consents",
+        title="Ver consentimientos",
+        group="privacy",
+        description="Devuelve los consentimientos activos del usuario autenticado.",
+        response_body="""\
+[
+  {
+    "id": 1,
+    "consent_type": "data_processing",
+    "granted": true,
+    "granted_at": "2026-01-15 10:30:00",
+    "revoked_at": null,
+    "policy_version": "1.0"
+  }
+]""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl {API_BASE}/privacy/consents \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" """,
+            ),
+        ],
+    ),
+    Endpoint(
+        method="POST",
+        path="/privacy/consents",
+        slug="grant-consent",
+        title="Otorgar consentimiento",
+        group="privacy",
+        description=(
+            "Registra el consentimiento del usuario para un tipo de procesamiento de datos. "
+            "Cumple con los requisitos de consentimiento informado de la LFPDPPP."
+        ),
+        params=[
+            Param(
+                "consent_type",
+                "body",
+                "string",
+                True,
+                'Tipo de consentimiento (ej: "data_processing")',
+            ),
+            Param(
+                "policy_version",
+                "body",
+                "string",
+                False,
+                'Version de la politica aceptada (default: "1.0")',
+            ),
+        ],
+        request_body="""\
+{
+  "consent_type": "data_processing",
+  "policy_version": "1.0"
+}""",
+        response_body="""\
+{
+  "id": 1,
+  "consent_type": "data_processing",
+  "granted": true,
+  "granted_at": "2026-03-26 14:00:00",
+  "revoked_at": null,
+  "policy_version": "1.0"
+}""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl -X POST {API_BASE}/privacy/consents \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" \\
+  -H "Content-Type: application/json" \\
+  -d '{{"consent_type": "data_processing", "policy_version": "1.0"}}'""",
+            ),
+        ],
+    ),
+    Endpoint(
+        method="DELETE",
+        path="/privacy/consents/{consent_type}",
+        slug="revoke-consent",
+        title="Revocar consentimiento",
+        group="privacy",
+        description=("Revoca un consentimiento activo. Cumple con el derecho de oposicion (ARCO)."),
+        params=[
+            Param("consent_type", "path", "string", True, "Tipo de consentimiento a revocar"),
+        ],
+        response_body='{ "detail": "Consentimiento revocado exitosamente" }',
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl -X DELETE {API_BASE}/privacy/consents/data_processing \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" """,
+            ),
+        ],
+    ),
+    Endpoint(
+        method="DELETE",
+        path="/privacy/my-data",
+        slug="delete-my-data",
+        title="Eliminar mis datos",
+        group="privacy",
+        description=(
+            "Elimina todos los datos personales de extraccion del usuario (registros de "
+            "extraccion y pruebas). Cumple con el derecho de cancelacion (ARCO). "
+            "Esta accion es irreversible."
+        ),
+        response_body="""\
+{
+  "extraction_logs_deleted": 42,
+  "test_logs_deleted": 5
+}""",
+        examples=[
+            CodeExample(
+                "curl",
+                "cURL",
+                f"""\
+curl -X DELETE {API_BASE}/privacy/my-data \\
+  -H "Authorization: Bearer {TOKEN_PLACEHOLDER}" """,
+            ),
+            CodeExample(
+                "python",
+                "Python",
+                f"""\
+import requests
+
+resp = requests.delete(
+    "{API_BASE}/privacy/my-data",
+    headers={{"Authorization": "Bearer {TOKEN_PLACEHOLDER}"}},
+)
+data = resp.json()
+print(f"Eliminados: {{data['extraction_logs_deleted']}} extracciones, "
+      f"{{data['test_logs_deleted']}} pruebas")""",
+            ),
+        ],
+        notes=(
+            "Solo elimina registros de extraccion y pruebas. La cuenta de usuario, "
+            "extractores y tokens no se eliminan. Para eliminar la cuenta completa, "
+            "contacta al administrador."
+        ),
     ),
 ]
 

--- a/backend/src/infrastructure/api/docs/router.py
+++ b/backend/src/infrastructure/api/docs/router.py
@@ -46,6 +46,16 @@ async def docs_index(request: Request):
     return _render("index.html", request, title="Inicio", **_common_context("index"))
 
 
+@router.get("/privacy-policy", response_class=HTMLResponse)
+async def docs_privacy_policy(request: Request):
+    return _render(
+        "privacy-policy.html",
+        request,
+        title="Politica de privacidad",
+        **_common_context("privacy-policy"),
+    )
+
+
 @router.get("/{slug}", response_class=HTMLResponse)
 async def docs_endpoint(slug: str, request: Request):
     ep = _ENDPOINT_MAP.get(slug)

--- a/backend/src/infrastructure/api/docs/templates/base.html
+++ b/backend/src/infrastructure/api/docs/templates/base.html
@@ -363,6 +363,7 @@
   </div>
 
   <a href="/api/docs" {% if active_slug == "index" %}class="active"{% endif %}>Inicio</a>
+  <a href="/api/docs/privacy-policy" {% if active_slug == "privacy-policy" %}class="active"{% endif %}>Politica de privacidad</a>
   <a href="/api/openapi.json" target="_blank">OpenAPI JSON</a>
 
   {% for group_id, group_label, endpoints in groups %}

--- a/backend/src/infrastructure/api/docs/templates/privacy-policy.html
+++ b/backend/src/infrastructure/api/docs/templates/privacy-policy.html
@@ -1,0 +1,226 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>Politica de Privacidad</h2>
+
+<p>
+  Extracto procesa documentos que pueden contener informacion personal y financiera.
+  Este documento describe como se recopilan, almacenan, protegen y eliminan los datos
+  de los usuarios, en cumplimiento con la legislacion mexicana aplicable.
+</p>
+
+<h3>Marco legal</h3>
+
+<div class="card" style="padding: 0; overflow: hidden;">
+  <table class="params-table" style="margin: 0;">
+    <thead>
+      <tr>
+        <th>Regulacion</th>
+        <th>Descripcion</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>LFPDPPP</strong></td>
+        <td>Ley Federal de Proteccion de Datos Personales en Posesion de los Particulares. Establece principios para el tratamiento de datos personales, incluyendo derechos ARCO (Acceso, Rectificacion, Cancelacion y Oposicion)</td>
+      </tr>
+      <tr>
+        <td><strong>INAI</strong></td>
+        <td>Lineamientos del Aviso de Privacidad. Define como informar a los usuarios sobre el uso de sus datos</td>
+      </tr>
+      <tr>
+        <td><strong>CNBV</strong></td>
+        <td>Estandares de seguridad de la Comision Nacional Bancaria y de Valores para informacion financiera sensible</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<h3>Datos que se recopilan</h3>
+
+<p>Al usar Extracto, se procesan los siguientes tipos de datos:</p>
+
+<div class="card" style="padding: 0; overflow: hidden;">
+  <table class="params-table" style="margin: 0;">
+    <thead>
+      <tr>
+        <th>Dato</th>
+        <th>Sensibilidad</th>
+        <th>Medidas de proteccion</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Documentos subidos</strong> (PDF, imagenes)</td>
+        <td>Alta</td>
+        <td>Almacenamiento cifrado en S3, URLs pre-firmadas con expiracion</td>
+      </tr>
+      <tr>
+        <td><strong>Campos extraidos</strong> (CLABE, nombres, etc.)</td>
+        <td>Alta</td>
+        <td>Cifrado en reposo con Fernet (AES-CBC + HMAC-SHA256)</td>
+      </tr>
+      <tr>
+        <td><strong>Campos corregidos por el usuario</strong></td>
+        <td>Alta</td>
+        <td>Cifrado en reposo con Fernet (AES-CBC + HMAC-SHA256)</td>
+      </tr>
+      <tr>
+        <td><strong>Cuenta de GitHub</strong> (nombre, email)</td>
+        <td>Media</td>
+        <td>Obtenido via OAuth, no se almacena la contrasena</td>
+      </tr>
+      <tr>
+        <td><strong>Registros de uso</strong> (timestamps, acciones)</td>
+        <td>Baja</td>
+        <td>Registros de auditoria con acceso restringido</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<h3>Cifrado de datos</h3>
+
+<p>Extracto implementa cifrado en dos niveles:</p>
+
+<ul style="color: var(--text-muted); padding-left: 20px; margin-bottom: 16px;">
+  <li>
+    <strong style="color: var(--text);">En transito:</strong>
+    HTTPS/TLS con cabeceras de seguridad (HSTS, X-Content-Type-Options, X-Frame-Options, CSP)
+  </li>
+  <li>
+    <strong style="color: var(--text);">En reposo:</strong>
+    Cifrado a nivel de campo con Fernet (AES-CBC + HMAC-SHA256) para los campos sensibles
+    de los registros de extraccion (<code>extracted_fields</code> y <code>final_fields</code>)
+  </li>
+</ul>
+
+<h3>Control de acceso</h3>
+
+<ul style="color: var(--text-muted); padding-left: 20px; margin-bottom: 16px;">
+  <li>
+    <strong style="color: var(--text);">RBAC</strong> con tres roles: <code>user</code>, <code>admin</code>, <code>guest</code>
+  </li>
+  <li>
+    <strong style="color: var(--text);">Autenticacion:</strong> GitHub OAuth + JWT para sesiones web, tokens API (<code>exto_</code>) para acceso programatico
+  </li>
+  <li>
+    <strong style="color: var(--text);">Aislamiento:</strong> cada usuario solo accede a sus propios datos (extractores, extracciones, tokens)
+  </li>
+  <li>
+    <strong style="color: var(--text);">URLs pre-firmadas:</strong> acceso temporal a documentos en S3 con expiracion automatica
+  </li>
+</ul>
+
+<h3>Procesamiento con modelos de IA</h3>
+
+<p>
+  Los documentos se envian a la API de Claude (Anthropic) para extraer los campos
+  definidos por el extractor. Anthropic no usa los datos enviados via API para
+  entrenar sus modelos. Los documentos se procesan en tiempo real y no se almacenan
+  en los servidores de Anthropic despues del procesamiento.
+</p>
+
+<p>
+  Para evaluaciones internas y analisis, el sistema incluye un modulo de anonimizacion
+  que transforma la informacion personal antes de su uso:
+</p>
+
+<div class="card" style="padding: 0; overflow: hidden;">
+  <table class="params-table" style="margin: 0;">
+    <thead>
+      <tr>
+        <th>Campo</th>
+        <th>Tecnica</th>
+        <th>Ejemplo</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>CLABE / cuenta</td>
+        <td>Tokenizacion (hash SHA-256)</td>
+        <td><code>012345678901234567</code> &rarr; <code>839172650483927156</code></td>
+      </tr>
+      <tr>
+        <td>Titular / nombre</td>
+        <td>Pseudonimizacion</td>
+        <td><code>Juan Perez</code> &rarr; <code>TITULAR_A3F8C2D1</code></td>
+      </tr>
+      <tr>
+        <td>RFC</td>
+        <td>Enmascaramiento parcial</td>
+        <td><code>ABCD123456XYZ</code> &rarr; <code>ABCD******XYZ</code></td>
+      </tr>
+      <tr>
+        <td>CURP</td>
+        <td>Enmascaramiento parcial</td>
+        <td><code>ABCD123456HDFRRL01</code> &rarr; <code>ABCD************01</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<h3>Derechos ARCO</h3>
+
+<p>
+  Los usuarios pueden ejercer sus derechos de Acceso, Rectificacion, Cancelacion
+  y Oposicion sobre sus datos personales a traves de la API:
+</p>
+
+<div class="card" style="padding: 0; overflow: hidden;">
+  <table class="params-table" style="margin: 0;">
+    <thead>
+      <tr>
+        <th>Derecho</th>
+        <th>Endpoint</th>
+        <th>Descripcion</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Acceso</strong></td>
+        <td><code><a href="/api/docs/list-consents">GET /privacy/consents</a></code></td>
+        <td>Ver consentimientos otorgados</td>
+      </tr>
+      <tr>
+        <td><strong>Oposicion</strong></td>
+        <td><code><a href="/api/docs/revoke-consent">DELETE /privacy/consents/{tipo}</a></code></td>
+        <td>Revocar un consentimiento</td>
+      </tr>
+      <tr>
+        <td><strong>Cancelacion</strong></td>
+        <td><code><a href="/api/docs/delete-my-data">DELETE /privacy/my-data</a></code></td>
+        <td>Eliminar todos los datos de extraccion</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<h3>Retencion de datos</h3>
+
+<ul style="color: var(--text-muted); padding-left: 20px; margin-bottom: 16px;">
+  <li>
+    <strong style="color: var(--text);">Politica de retencion:</strong>
+    5 anos (cumplimiento fiscal mexicano), despues de lo cual los datos se eliminan automaticamente
+  </li>
+  <li>
+    <strong style="color: var(--text);">Eliminacion anticipada:</strong>
+    el usuario puede solicitar la eliminacion de sus datos en cualquier momento
+    via <a href="/api/docs/delete-my-data">DELETE /privacy/my-data</a>
+  </li>
+  <li>
+    <strong style="color: var(--text);">Purga administrativa:</strong>
+    los administradores pueden ejecutar la purga de datos expirados
+  </li>
+</ul>
+
+<h3>Auditoria</h3>
+
+<p>
+  Todas las acciones sensibles se registran automaticamente en un log de auditoria
+  que incluye: usuario, accion, recurso afectado, direccion IP y timestamp.
+  Las acciones auditadas incluyen: otorgamiento/revocacion de consentimientos,
+  eliminacion de datos y purgas administrativas.
+</p>
+
+{% endblock %}

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -220,6 +220,10 @@ CLIENT_ENDPOINT_WHITELIST = {
     ("GET", "/tokens"),
     ("POST", "/tokens"),
     ("DELETE", "/tokens/{token_id}"),
+    ("GET", "/privacy/consents"),
+    ("POST", "/privacy/consents"),
+    ("DELETE", "/privacy/consents/{consent_type}"),
+    ("DELETE", "/privacy/my-data"),
 }
 
 


### PR DESCRIPTION
## Summary
- Adds a static privacy policy page at `/api/docs/privacy-policy` with legal framework (LFPDPPP, INAI, CNBV), encryption details, ARCO rights, data retention, and anonymization techniques
- Exposes 4 privacy endpoints in the client API documentation sidebar and OpenAPI spec: `GET/POST /privacy/consents`, `DELETE /privacy/consents/{type}`, `DELETE /privacy/my-data`
- Adds "Politica de privacidad" link to the `/api/docs` sidebar navigation

## Test plan
- [ ] Visit `/api/docs` and verify the "Politica de privacidad" link appears in the sidebar
- [ ] Visit `/api/docs/privacy-policy` and verify the page renders correctly
- [ ] Verify the 4 privacy endpoints appear in the sidebar under "Privacidad"
- [ ] Visit each privacy endpoint page and verify examples render
- [ ] Verify `/api/openapi.json` includes the privacy endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)