### PR TITLE
Fix bank statement validation applying to all default extractors

### DIFF
--- a/backend/src/domain/services/extraction.py
+++ b/backend/src/domain/services/extraction.py
@@ -119,9 +119,12 @@ class ExtractionService:
 
             elapsed_ms = round((time.monotonic() - start) * 1000, 1)
 
-            # Apply bank-statement-specific logic for default extractor
+            # Apply bank-statement-specific logic only for bank statement extractors
             is_default = config is None or config.is_default
-            if is_default:
+            has_bank_fields = config is None or "account_number" in config.output_schema.get(
+                "properties", {}
+            )
+            if is_default and has_bank_fields:
                 raw_result = retry_bank_statement_clabe(extractor, tmp_file_path, raw_result)
                 try:
                     raw_result = apply_bank_statement_postprocessing(raw_result)


### PR DESCRIPTION
## Summary
- **Backend**: La lógica de post-procesamiento de estados de cuenta bancarios (`apply_bank_statement_postprocessing` y `retry_bank_statement_clabe`) se aplicaba a todo extractor con `is_default=True`. Ahora verifica que el `output_schema` contenga `account_number` antes de aplicar
- **Frontend**: El formulario hardcodeado de bank statement (Titular, Banco, CLABE) se mostraba para cualquier extractor default. Ahora usa `DynamicFieldsForm` para extractores default que no son de bank statement

## Test plan
- [ ] Extraer un documento con "Boletas y recibos" — debe mostrar los campos dinámicos (comercio, fecha, productos, etc.) sin error de estado de cuenta
- [ ] Extraer un estado de cuenta bancario — debe seguir mostrando Titular/Banco/CLABE con validación CLABE
- [ ] `pytest` pasa (169 tests)
- [ ] Frontend lint pasa

🤖 Generated with [Claude Code](https://claude.com/claude-code)