### PR TITLE
Fix frontend showing bank statement fields for all default extractors

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -71,7 +71,10 @@ export default function Home() {
   }, [extractorConfigs, selectedExtractorId, setSelectedExtractorId]);
 
   const selectedConfig = extractorConfigs.find((c) => c.id === selectedExtractorId);
-  const isDefaultExtractor = selectedConfig?.is_default ?? true;
+  const isBankStatementExtractor =
+    (selectedConfig?.is_default ?? true) &&
+    "account_number" in
+      ((selectedConfig?.output_schema as Record<string, Record<string, unknown>>)?.properties ?? {});
 
   const handleFileSelect = async (selectedFile: File) => {
     setFile(selectedFile);
@@ -286,7 +289,7 @@ export default function Home() {
                 <CardHeader>
                   <CardTitle>{t("extraction.extractedInfo")}</CardTitle>
                   <CardDescription>
-                    {isDefaultExtractor
+                    {isBankStatementExtractor
                       ? t("extraction.reviewDefault")
                       : `${t("extraction.extractor")}: ${selectedConfig?.name}`}
                     {extracted?.extractor_config_version_number != null && (
@@ -355,7 +358,7 @@ export default function Home() {
                     </div>
                   ) : (
                     <form onSubmit={handleSubmit} className="space-y-4">
-                      {isDefaultExtractor ? (
+                      {isBankStatementExtractor ? (
                         <>
                           <div className="space-y-2">
                             <Label htmlFor="owner">{t("extraction.owner")}</Label>


### PR DESCRIPTION
## Summary
- El formulario hardcodeado de bank statement (Titular, Banco, CLABE) se mostraba para cualquier extractor con `is_default=true`, incluyendo "Boletas y recibos"
- Ahora verifica que el `output_schema` del extractor contenga `account_number` antes de mostrar los campos bancarios
- Extractores default sin campos bancarios usan `DynamicFieldsForm` con su schema correcto

Complementa el fix del backend en #43.

## Test plan
- [ ] Extraer documento con "Boletas y recibos" — debe mostrar campos dinámicos (comercio, fecha, productos, etc.)
- [ ] Extraer estado de cuenta bancario — debe seguir mostrando Titular/Banco/CLABE
- [ ] Frontend lint pasa

🤖 Generated with [Claude Code](https://claude.com/claude-code)