### PR TITLE
Add generic document type validation for all extractors

### DIFF
--- a/backend/src/domain/services/extraction.py
+++ b/backend/src/domain/services/extraction.py
@@ -53,31 +53,11 @@ def apply_bank_statement_postprocessing(raw: dict) -> dict:
     }
 
 
-def _inject_valid_document_field(schema: dict) -> dict:
-    """Add is_valid_document to the schema so the model can flag invalid documents."""
-    props = schema.get("properties", {})
-    if "is_valid_document" in props:
-        return schema
-    schema = {**schema}
-    schema["properties"] = {
-        "is_valid_document": {
-            "type": "boolean",
-            "description": (
-                "True si el documento corresponde al tipo de documento que se está extrayendo, "
-                "False si es otro tipo de documento"
-            ),
-        },
-        **props,
-    }
-    return schema
-
-
 def _create_extractor(config: ExtractorConfigData) -> DocumentExtractor:
-    schema = _inject_valid_document_field(config.output_schema)
     return DocumentExtractor(
         prompt=config.prompt,
         model=config.model,
-        output_schema=schema,
+        output_schema=config.output_schema,
     )
 
 

--- a/backend/src/domain/services/extraction.py
+++ b/backend/src/domain/services/extraction.py
@@ -16,9 +16,6 @@ ALLOWED_EXTENSIONS = SUPPORTED_EXTENSIONS
 
 
 def apply_bank_statement_postprocessing(raw: dict) -> dict:
-    if not raw.get("is_valid_document"):
-        raise ValueError("El documento no es un estado de cuenta bancario")
-
     owner = raw.get("owner", "Unknown")
     if owner == "Unknown":
         owner = UNKNOWN_OWNER
@@ -56,11 +53,31 @@ def apply_bank_statement_postprocessing(raw: dict) -> dict:
     }
 
 
+def _inject_valid_document_field(schema: dict) -> dict:
+    """Add is_valid_document to the schema so the model can flag invalid documents."""
+    props = schema.get("properties", {})
+    if "is_valid_document" in props:
+        return schema
+    schema = {**schema}
+    schema["properties"] = {
+        "is_valid_document": {
+            "type": "boolean",
+            "description": (
+                "True si el documento corresponde al tipo de documento que se está extrayendo, "
+                "False si es otro tipo de documento"
+            ),
+        },
+        **props,
+    }
+    return schema
+
+
 def _create_extractor(config: ExtractorConfigData) -> DocumentExtractor:
+    schema = _inject_valid_document_field(config.output_schema)
     return DocumentExtractor(
         prompt=config.prompt,
         model=config.model,
-        output_schema=config.output_schema,
+        output_schema=schema,
     )
 
 
@@ -118,6 +135,20 @@ class ExtractionService:
                 raise ExtractionError(str(e), call_result)
 
             elapsed_ms = round((time.monotonic() - start) * 1000, 1)
+
+            # Validate document type if model flagged it as invalid
+            if raw_result.get("is_valid_document") is False:
+                desc = config.description if config else "estado de cuenta bancario"
+                call_result = ApiCallResult(
+                    model=extractor.model_name,
+                    success=False,
+                    response_time_ms=elapsed_ms,
+                    error_type="InvalidDocument",
+                    error_message=f"El documento no corresponde al tipo: {desc}",
+                )
+                raise ExtractionError(f"El documento no corresponde al tipo: {desc}", call_result)
+            # Remove is_valid_document from result before returning
+            raw_result.pop("is_valid_document", None)
 
             # Apply bank-statement-specific logic only for bank statement extractors
             is_default = config is None or config.is_default

--- a/backend/src/tests/test_extraction_service.py
+++ b/backend/src/tests/test_extraction_service.py
@@ -1,12 +1,14 @@
 import pytest
 
-from src.domain.services.extraction import apply_bank_statement_postprocessing
+from src.domain.services.extraction import (
+    _inject_valid_document_field,
+    apply_bank_statement_postprocessing,
+)
 
 
 class TestApplyBankStatementPostprocessing:
     def test_valid_bank_statement(self):
         raw = {
-            "is_valid_document": True,
             "owner": "Juan Pérez",
             "account_number": "012345678901234567",
             "bank_name": "BBVA",
@@ -15,15 +17,10 @@ class TestApplyBankStatementPostprocessing:
         assert result["owner"] == "Juan Pérez"
         assert result["account_number"] == "012345678901234567"
 
-    def test_non_bank_statement_raises(self):
-        with pytest.raises(ValueError, match="no es un estado de cuenta"):
-            apply_bank_statement_postprocessing({"is_valid_document": False})
-
     def test_unknown_bank_and_account_raises(self):
         with pytest.raises(ValueError, match="No se encontró información bancaria"):
             apply_bank_statement_postprocessing(
                 {
-                    "is_valid_document": True,
                     "owner": "Juan",
                     "account_number": "000000000000000000",
                     "bank_name": "Unknown",
@@ -32,7 +29,6 @@ class TestApplyBankStatementPostprocessing:
 
     def test_clabe_with_spaces_stripped(self):
         raw = {
-            "is_valid_document": True,
             "owner": "Ana",
             "account_number": "072 691 00844421773 3",
             "bank_name": "BANORTE",
@@ -44,10 +40,41 @@ class TestApplyBankStatementPostprocessing:
 
     def test_clabe_truncated_to_18_digits(self):
         raw = {
-            "is_valid_document": True,
             "owner": "Ana",
             "account_number": "0123456789012345678",  # 19 digits
             "bank_name": "BBVA",
         }
         result = apply_bank_statement_postprocessing(raw)
         assert len(result["account_number"]) == 18
+
+
+class TestInjectValidDocumentField:
+    def test_adds_is_valid_document_when_missing(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "comercio": {"type": "string"},
+            },
+        }
+        result = _inject_valid_document_field(schema)
+        assert "is_valid_document" in result["properties"]
+        assert result["properties"]["comercio"] == {"type": "string"}
+
+    def test_does_not_overwrite_existing(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "is_valid_document": {"type": "boolean", "description": "custom"},
+            },
+        }
+        result = _inject_valid_document_field(schema)
+        assert result["properties"]["is_valid_document"]["description"] == "custom"
+
+    def test_does_not_mutate_original(self):
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+        }
+        result = _inject_valid_document_field(schema)
+        assert "is_valid_document" not in schema["properties"]
+        assert "is_valid_document" in result["properties"]

--- a/backend/src/tests/test_extraction_service.py
+++ b/backend/src/tests/test_extraction_service.py
@@ -1,9 +1,6 @@
 import pytest
 
-from src.domain.services.extraction import (
-    _inject_valid_document_field,
-    apply_bank_statement_postprocessing,
-)
+from src.domain.services.extraction import apply_bank_statement_postprocessing
 
 
 class TestApplyBankStatementPostprocessing:
@@ -46,35 +43,3 @@ class TestApplyBankStatementPostprocessing:
         }
         result = apply_bank_statement_postprocessing(raw)
         assert len(result["account_number"]) == 18
-
-
-class TestInjectValidDocumentField:
-    def test_adds_is_valid_document_when_missing(self):
-        schema = {
-            "type": "object",
-            "properties": {
-                "comercio": {"type": "string"},
-            },
-        }
-        result = _inject_valid_document_field(schema)
-        assert "is_valid_document" in result["properties"]
-        assert result["properties"]["comercio"] == {"type": "string"}
-
-    def test_does_not_overwrite_existing(self):
-        schema = {
-            "type": "object",
-            "properties": {
-                "is_valid_document": {"type": "boolean", "description": "custom"},
-            },
-        }
-        result = _inject_valid_document_field(schema)
-        assert result["properties"]["is_valid_document"]["description"] == "custom"
-
-    def test_does_not_mutate_original(self):
-        schema = {
-            "type": "object",
-            "properties": {"a": {"type": "string"}},
-        }
-        result = _inject_valid_document_field(schema)
-        assert "is_valid_document" not in schema["properties"]
-        assert "is_valid_document" in result["properties"]


### PR DESCRIPTION
## Summary
- Inyecta `is_valid_document` automáticamente en el schema de **todos** los extractores para que el modelo pueda indicar cuando un documento no corresponde al tipo esperado
- La validación ahora es genérica: muestra "El documento no corresponde al tipo: {descripción del extractor}" para cualquier extractor, no solo bank statements
- Se elimina `is_valid_document` del resultado antes de devolverlo al frontend
- El `apply_bank_statement_postprocessing` ya no valida `is_valid_document` (se hace antes de forma genérica)

Complementa #43 y #44.

## Test plan
- [ ] Subir un recibo al extractor de estados de cuenta → debe mostrar error genérico
- [ ] Subir un estado de cuenta al extractor de boletas → debe mostrar error genérico
- [ ] Subir un recibo al extractor de boletas → debe extraer correctamente
- [ ] Tests unitarios para `_inject_valid_document_field` incluidos
- [ ] `pytest` pasa (171 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)