### PR TITLE
Prevent creating API tokens with past expiration dates

### DIFF
--- a/backend/src/infrastructure/api/tokens/routes.py
+++ b/backend/src/infrastructure/api/tokens/routes.py
@@ -1,8 +1,8 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from sqlalchemy.orm import Session
 
 from src.infrastructure.auth import UserDep, generate_api_token, hash_token
@@ -15,6 +15,13 @@ router = APIRouter(prefix="/tokens", tags=["tokens"])
 class CreateTokenRequest(BaseModel):
     name: str
     expires_at: datetime | None = None
+
+    @field_validator("expires_at")
+    @classmethod
+    def expires_at_must_be_future(cls, v: datetime | None) -> datetime | None:
+        if v is not None and v < datetime.now(timezone.utc):
+            raise ValueError("La fecha de expiración debe ser en el futuro")
+        return v
 
 
 class TokenResponse(BaseModel):

--- a/frontend/app/settings/tokens/page.tsx
+++ b/frontend/app/settings/tokens/page.tsx
@@ -169,6 +169,7 @@ export default function TokensPage() {
               <input
                 type="datetime-local"
                 value={expiresAt}
+                min={new Date().toISOString().slice(0, 16)}
                 onChange={(e) => setExpiresAt(e.target.value)}
                 className="mt-1 block rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500"
               />


### PR DESCRIPTION
## Summary
- **Backend**: Agrega `field_validator` en `CreateTokenRequest` que rechaza `expires_at` en el pasado con error "La fecha de expiración debe ser en el futuro"
- **Frontend**: Agrega atributo `min` al input `datetime-local` para que no permita seleccionar fechas pasadas

## Test plan
- [ ] Intentar crear token con fecha pasada desde el frontend — el input no debe permitirlo
- [ ] `POST /tokens` con `expires_at` en el pasado — debe retornar 422
- [ ] Crear token con fecha futura — debe funcionar normal
- [ ] Crear token sin fecha de expiración — debe funcionar normal
- [ ] `pytest` pasa (168 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)