### PR TITLE
Fix orientation check skipped for image URL extraction

### DIFF
--- a/backend/src/infrastructure/extractors/document_extractor.py
+++ b/backend/src/infrastructure/extractors/document_extractor.py
@@ -356,6 +356,17 @@ class DocumentExtractor:
         if suffix in PDF_EXTENSIONS:
             return self._extract_with_pdf(file_path)
         elif image_url and image_url.startswith("https://"):
+            # Check orientation before deciding whether to use URL or base64
+            image = Image.open(file_path)
+            if image.mode != "RGB":
+                image = image.convert("RGB")
+            image_b64 = self._image_to_base64(image)
+            rotation = self._check_orientation(image_b64)
+            if rotation != 0:
+                _logger().info("Image rotated %d°, sending as base64 instead of URL", rotation)
+                image = image.rotate(-rotation, expand=True)
+                image_b64 = self._image_to_base64(image)
+                return self._extract_with_vision([image_b64])
             return self._extract_with_vision(image_url=image_url)
         else:
             base64_images = self._load_image_file(file_path)

--- a/backend/src/tests/test_multi_provider.py
+++ b/backend/src/tests/test_multi_provider.py
@@ -240,25 +240,71 @@ class TestPdfFallbackForNonAnthropicProviders:
 
 class TestExtractFileWithImageUrl:
     @patch("src.infrastructure.extractors.document_extractor._create_llm")
-    def test_image_url_skips_base64(self, mock_create):
+    def test_image_url_uses_url_when_no_rotation(self, mock_create):
         mock_llm = MagicMock()
-        mock_llm.with_structured_output.return_value.invoke.return_value = {
-            "is_valid_document": True,
-            "owner": "Test",
-            "account_number": "012345678901234567",
-            "bank_name": "BBVA",
-        }
+        mock_llm.with_structured_output.return_value.invoke.return_value = {"field": "value"}
         mock_create.return_value = mock_llm
 
         ext = _make_extractor(model="gpt-4o-mini", api_key="fake")
 
-        with patch.object(ext, "_load_image_file") as mock_load:
+        fake_img = MagicMock()
+        fake_img.mode = "RGB"
+        fake_img.width = 100
+        fake_img.height = 100
+        fake_img.save = MagicMock(side_effect=lambda buf, **kw: buf.write(b"\xff\xd8fake"))
+
+        with (
+            patch(
+                "src.infrastructure.extractors.document_extractor.Image.open",
+                return_value=fake_img,
+            ),
+            patch.object(ext, "_check_orientation", return_value=0) as mock_orient,
+        ):
             result = ext.extract_file(
                 Path("/fake/file.jpg"), image_url="https://s3.example.com/file.jpg"
             )
 
-        mock_load.assert_not_called()
-        assert result["owner"] == "Test"
+        mock_orient.assert_called_once()
+        # Should use URL path, not base64
+        call_args = ext.structured_llm.invoke.call_args[0][0][0]
+        img_block = call_args.content[0]
+        assert img_block["image_url"]["url"] == "https://s3.example.com/file.jpg"
+        assert result == {"field": "value"}
+
+    @patch("src.infrastructure.extractors.document_extractor._create_llm")
+    def test_image_url_uses_base64_when_rotated(self, mock_create):
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output.return_value.invoke.return_value = {"field": "value"}
+        mock_create.return_value = mock_llm
+
+        ext = _make_extractor(model="gpt-4o-mini", api_key="fake")
+
+        fake_img = MagicMock()
+        fake_img.mode = "RGB"
+        fake_img.width = 100
+        fake_img.height = 100
+        fake_img.save = MagicMock(side_effect=lambda buf, **kw: buf.write(b"\xff\xd8fake"))
+        fake_img.rotate.return_value = fake_img
+
+        with (
+            patch(
+                "src.infrastructure.extractors.document_extractor.Image.open",
+                return_value=fake_img,
+            ),
+            patch.object(ext, "_check_orientation", return_value=90) as mock_orient,
+        ):
+            result = ext.extract_file(
+                Path("/fake/file.jpg"), image_url="https://s3.example.com/file.jpg"
+            )
+
+        mock_orient.assert_called_once()
+        fake_img.rotate.assert_called_once_with(-90, expand=True)
+        # Should use base64 path since image was rotated
+        call_args = ext.structured_llm.invoke.call_args[0][0][0]
+        img_block = call_args.content[0]
+        assert img_block["type"] == "image_url"
+        assert img_block["image_url"]["url"].startswith("data:image/jpeg;base64,")
+        assert result == {"field": "value"}
 
     @patch("src.infrastructure.extractors.document_extractor._create_llm")
     def test_pdf_ignores_image_url(self, mock_create):


### PR DESCRIPTION
## Summary
- In production, images with S3 presigned URLs were sent directly to the LLM without checking orientation, causing wrong extraction results for rotated images (e.g., extracting data from the wrong person on a rotated ID card)
- Now `extract_file` checks orientation first when an image URL is provided: if rotation is needed, the corrected image is sent as base64; if not, the URL fast path is preserved
- Updated tests to cover both the no-rotation (URL) and rotation (base64) paths

## Test plan
- [x] `ruff check` passes
- [x] `pytest` — all 177 tests pass
- [ ] Test in prod with a rotated image (e.g., IMG_8400.jpg) to verify correct extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)