### PR TITLE
Fix OCR failing on large PDF images in prod

### DIFF
--- a/backend/src/infrastructure/extractors/document_extractor.py
+++ b/backend/src/infrastructure/extractors/document_extractor.py
@@ -241,6 +241,13 @@ class DocumentExtractor:
             img = self._pdf_to_image(pdf_path)
             if img is None:
                 return None
+            # Resize large images to avoid tesseract memory issues
+            max_dim = 2048
+            if img.width > max_dim or img.height > max_dim:
+                ratio = min(max_dim / img.width, max_dim / img.height)
+                new_size = (int(img.width * ratio), int(img.height * ratio))
+                _logger().info("Resizing for OCR: %dx%d → %dx%d", img.width, img.height, *new_size)
+                img = img.resize(new_size, Image.Resampling.LANCZOS)
             text = pytesseract.image_to_string(img)
             if text and text.strip():
                 _logger().info("OCR extracted %d chars from PDF", len(text))


### PR DESCRIPTION
## Summary
- Large PDF pages (e.g. 6317x8155 pixels) cause tesseract to fail intermittently with error `(-9, '')` in prod, falling back to native PDF extraction which misreads CLABEs
- Resize the PDF-to-image output to max 2048px before running OCR — sufficient for text extraction and avoids tesseract memory issues

## Test plan
- [x] `ruff check` passes
- [x] `pytest` — all 177 tests pass
- [ ] Test in prod with heavy single-page PDFs (e.g. row016_CENTRO_ESCOLAR_GREEN_HILLS.pdf) to verify OCR no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)